### PR TITLE
[IMP] rental_base: correction to fields and method

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,7 @@ repos:
     rev: 20.8b1
     hooks:
       - id: black
+        additional_dependencies: ["click==8.0.4"]
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.1.2
     hooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ addons:
   apt:
     packages:
       - expect-dev # provides unbuffer utility
+      - python-lxml # because pip installation is slow
+      - libxml2-dev
+      - libxmlsec1-dev
+      - libxslt-dev
+      - swig
 
 stages:
   - test

--- a/rental_base/models/sale.py
+++ b/rental_base/models/sale.py
@@ -14,12 +14,14 @@ class SaleOrder(models.Model):
         string="Default Start Date",
         compute="_compute_default_start_date",
         readonly=False,
+        store=True,
     )
 
     default_end_date = fields.Date(
         string="Default End Date",
         compute="_compute_default_end_date",
         readonly=False,
+        store=True,
     )
 
     @api.depends("order_line.start_date")
@@ -153,7 +155,7 @@ class SaleOrderLine(models.Model):
         self.ensure_one()
         res = super()._prepare_invoice_line(**optional_values)
         if self.product_id.income_analytic_account_id:
-            res["account_analytic_id"] = self.product_id.income_analytic_account_id.id
+            res["analytic_account_id"] = self.product_id.income_analytic_account_id.id
         return res
 
     @api.model

--- a/rental_base/views/sale_view.xml
+++ b/rental_base/views/sale_view.xml
@@ -29,8 +29,10 @@
     <record id="sale_start_end_dates" model="ir.ui.view">
         <field name="name">rental_base.sale_start_end_dates</field>
         <field name="model">sale.order</field>
+        <field name="priority">110</field> <!--Priority greater than 100-->
         <field name="inherit_id" ref="sale_start_end_dates.view_order_form" />
         <field name="arch" type="xml">
+            <!-- Use of position=replace: It is necessary to adjust view design -->
             <field name="default_start_date" position="replace" />
             <field name="default_end_date" position="replace" />
             <field name="validity_date" position="after">

--- a/rental_pricelist/views/product_view.xml
+++ b/rental_pricelist/views/product_view.xml
@@ -5,8 +5,10 @@
         <record id="product_normal_form_view" model="ir.ui.view">
             <field name="name">view.product.product.form</field>
             <field name="model">product.product</field>
+            <field name="priority">112</field> <!--Priority greater than 100-->
             <field name="inherit_id" ref="product.product_normal_form_view" />
             <field name="arch" type="xml">
+                <!-- Use of position=replace: It is necessary to adjust view design -->
                 <group name="rental-product" position="replace" />
                 <xpath expr="//notebook" position="inside">
                     <page
@@ -164,8 +166,10 @@
         <record id="product_template_only_form_view" model="ir.ui.view">
             <field name="name">view.product.template.form</field>
             <field name="model">product.template</field>
+            <field name="priority">111</field> <!--Priority greater than 100-->
             <field name="inherit_id" ref="product.product_template_only_form_view" />
             <field name="arch" type="xml">
+                <!-- Use of position=replace: It is necessary to adjust view design -->
                 <group name="rental-product-template" position="replace" />
             </field>
         </record>


### PR DESCRIPTION
1. user can see default start and end date on sale.order.line on Rental Order
2. correct field name to `analytic_account_id` to set a value on account.invoice.line from Product
3. fix pylint checks `dangerous-view-replace-wo-priority` after dotfile update [Ref PR#10](https://github.com/OCA/vertical-rental/pull/10) and for fix [useful link](https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#inherited-xml)
4. added python packages to `.travis.yml`