### PR TITLE
[FIX] change repo to github from gitlab for flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,7 +104,7 @@ repos:
     rev: 2.5.2
     hooks:
       - id: setuptools-odoo-make-default
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 3.7.9
     hooks:
       - id: flake8


### PR DESCRIPTION
A fix for this error:

```
[INFO] Initializing environment for https://gitlab.com/pycqa/flake8.
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags')
return code: 128
expected return code: 0
stdout: (none)
stderr:
    fatal: could not read Username for 'https://gitlab.com': No such device or address
    
Check the log at /home/runner/.cache/pre-commit/pre-commit.log
Error: The process '/opt/hostedtoolcache/Python/3.9.7/x[64](https://github.com/OCA/vertical-rental/actions/runs/3572857789/jobs/6006230988#step:4:66)/bin/pre-commit' failed with exit code 3
```