### PR TITLE
[16.0][ADD] rental_dashboard: Add new dashboard

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -4,11 +4,12 @@ env:
 
 # See https://github.com/OCA/odoo-community.org/issues/37#issuecomment-470686449
 parserOptions:
-  ecmaVersion: 2019
+  ecmaVersion: 2020
 
 overrides:
   - files:
       - "**/*.esm.js"
+      - "**/static/src/**/*.js"
     parserOptions:
       sourceType: module
 

--- a/rental_dashboard/README.rst
+++ b/rental_dashboard/README.rst
@@ -1,0 +1,85 @@
+================
+Rental Dashboard
+================
+
+A unified dashboard for managing rental operations, built as an OWL client action
+embedded in the Odoo backend.
+
+Features
+========
+
+Calendar View
+-------------
+Displays all active rental bookings on a month calendar, color-coded by customer.
+Users can see at a glance when equipment is booked and by whom.
+
+Product Sidebar
+---------------
+Lists all rental-eligible products with real-time availability (available / total fleet),
+calculated from warehouse stock minus committed rentals.
+
+Filtering
+---------
+Filter by warehouse location, date range, and stock availability. Selecting a location
+scopes both the product list and calendar to that warehouse. Date range highlights the
+selected period on the calendar and recalculates availability for that window.
+
+Quick Booking
+-------------
+Create rental orders directly from the dashboard: select products from the sidebar,
+drag a date range on the calendar, or click "Create rental". A modal lets you pick
+customer, warehouse, dates, equipment, rental period, and quantity — with live pricing
+and availability checks.
+
+Edit Bookings
+-------------
+Click any calendar event to open the rental order in an edit modal. View order status,
+modify lines, confirm the order, or navigate to the full sale order form.
+
+Hover Tooltips
+--------------
+Hovering over a calendar event shows a tooltip with product name, customer, order
+reference, dates, and quantity.
+
+Configuration
+=============
+
+1. Enable **Rental Allowed** on the warehouses you want to use for rentals
+   (Inventory > Configuration > Warehouses).
+2. Create physical products and use "Create Rental Service" on their form to make
+   them available for rental.
+3. Configure rental pricing per period on each rental service product
+   (product form > Rental Pricing tab).
+
+Usage
+=====
+
+1. Open the **Rentals** top-level menu.
+2. The **Dashboard** sub-menu opens the rental dashboard.
+3. Use the left sidebar to filter by location, dates, and availability.
+4. Click products to pre-select them, then click **Rent** or **Create rental**.
+5. Fill in customer, dates, equipment lines, and quantities in the modal.
+6. Click **Create Order** to save as a draft quotation, then optionally confirm.
+
+Dependencies
+============
+
+* ``sale_rental``
+
+Credits
+=======
+
+Authors
+-------
+
+* Trobz
+
+Contributors
+------------
+
+* Trobz
+
+Maintainers
+-----------
+
+This module is maintained by the OCA.

--- a/rental_dashboard/__init__.py
+++ b/rental_dashboard/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/rental_dashboard/__manifest__.py
+++ b/rental_dashboard/__manifest__.py
@@ -21,5 +21,6 @@
     },
     "installable": True,
     "application": True,
-    "license": "LGPL-3",
+    "license": "AGPL-3",
+    "website": "https://github.com/OCA/vertical-rental",
 }

--- a/rental_dashboard/__manifest__.py
+++ b/rental_dashboard/__manifest__.py
@@ -1,34 +1,25 @@
 {
-    'name': 'Rental Dashboard Sketch',
-    'version': '16.0.1.0.0',
-    'summary': 'Rental Dashboard with Calendar and Booking Management',
-    'description': """
-Rental Dashboard Sketch
-=======================
-A comprehensive rental management system with:
-- Rental bookings with customer and location management
-- Product availability calculation
-- Calendar view for bookings
-- Multi-location support
-    """,
-    'category': 'Rental',
-    'author': 'Kencove',
-    'depends': ['sale_rental'],
-    'data': [
-        'views/product_product_views.xml',
-        'views/sale_order_line_views.xml',
-        'views/dashboard_action.xml',
-        'views/menus.xml',
+    "name": "Rental Dashboard",
+    "version": "16.0.1.0.0",
+    "summary": "Rental Dashboard with Calendar and Booking Management",
+    "category": "Rental",
+    "author": "Trobz, Odoo Community Association (OCA)",
+    "depends": ["sale_rental"],
+    "data": [
+        "views/product_product_views.xml",
+        "views/sale_order_line_views.xml",
+        "views/dashboard_action.xml",
+        "views/menus.xml",
     ],
-    'demo': [],
-    'assets': {
-        'web.assets_backend': [
-            'rental_dashboard/static/src/scss/rental_dashboard.scss',
-            'rental_dashboard/static/src/js/rental_dashboard.js',
-            'rental_dashboard/static/src/xml/rental_dashboard.xml',
+    "demo": [],
+    "assets": {
+        "web.assets_backend": [
+            "rental_dashboard/static/src/scss/rental_dashboard.scss",
+            "rental_dashboard/static/src/js/rental_dashboard.js",
+            "rental_dashboard/static/src/xml/rental_dashboard.xml",
         ],
     },
-    'installable': True,
-    'application': True,
-    'license': 'LGPL-3',
+    "installable": True,
+    "application": True,
+    "license": "LGPL-3",
 }

--- a/rental_dashboard/__manifest__.py
+++ b/rental_dashboard/__manifest__.py
@@ -1,0 +1,34 @@
+{
+    'name': 'Rental Dashboard Sketch',
+    'version': '16.0.1.0.0',
+    'summary': 'Rental Dashboard with Calendar and Booking Management',
+    'description': """
+Rental Dashboard Sketch
+=======================
+A comprehensive rental management system with:
+- Rental bookings with customer and location management
+- Product availability calculation
+- Calendar view for bookings
+- Multi-location support
+    """,
+    'category': 'Rental',
+    'author': 'Kencove',
+    'depends': ['sale_rental'],
+    'data': [
+        'views/product_product_views.xml',
+        'views/sale_order_line_views.xml',
+        'views/dashboard_action.xml',
+        'views/menus.xml',
+    ],
+    'demo': [],
+    'assets': {
+        'web.assets_backend': [
+            'rental_dashboard/static/src/scss/rental_dashboard.scss',
+            'rental_dashboard/static/src/js/rental_dashboard.js',
+            'rental_dashboard/static/src/xml/rental_dashboard.xml',
+        ],
+    },
+    'installable': True,
+    'application': True,
+    'license': 'LGPL-3',
+}

--- a/rental_dashboard/models/__init__.py
+++ b/rental_dashboard/models/__init__.py
@@ -1,0 +1,2 @@
+from . import product
+from . import sale_order_line

--- a/rental_dashboard/models/product.py
+++ b/rental_dashboard/models/product.py
@@ -78,21 +78,25 @@ class ProductProduct(models.Model):
 
         rental_in_set = set(rental_in_ids)
 
-        # Stock at rental locations
-        quants = self.env["stock.quant"].search_read(
+        # Stock at rental locations — aggregate in SQL
+        quant_groups = self.env["stock.quant"].read_group(
             [("location_id", "in", all_location_ids), ("quantity", ">", 0)],
-            ["product_id", "quantity", "location_id"],
+            ["product_id", "location_id", "quantity:sum"],
+            ["product_id", "location_id"],
+            lazy=False,
         )
         rental_in_qty = {}
         total_qty = {}
-        for q in quants:
-            pid = q["product_id"][0]
-            qty = q["quantity"]
+        for g in quant_groups:
+            if not g.get("product_id"):
+                continue
+            pid = g["product_id"][0]
+            qty = g["quantity"]
             total_qty[pid] = total_qty.get(pid, 0) + qty
-            if q["location_id"][0] in rental_in_set:
+            if g["location_id"][0] in rental_in_set:
                 rental_in_qty[pid] = rental_in_qty.get(pid, 0) + qty
 
-        # Committed rental quantities
+        # Committed rental quantities — aggregate in SQL
         rental_domain = [("state", "=", "ordered")]
         if rental_in_ids:
             rental_domain.append(("out_picking_id.location_id", "in", rental_in_ids))
@@ -100,13 +104,16 @@ class ProductProduct(models.Model):
             rental_domain.append(("start_datetime", "<=", date_to or date_from))
         if date_to:
             rental_domain.append(("end_datetime", ">=", date_from or date_to))
-        rentals = self.env["sale.rental"].search_read(
-            rental_domain, ["rented_product_id", "rental_qty"]
+        rental_groups = self.env["sale.rental"].read_group(
+            rental_domain,
+            ["rented_product_id", "rental_qty:sum"],
+            ["rented_product_id"],
         )
-        committed_qty = {}
-        for r in rentals:
-            pid = r["rented_product_id"][0]
-            committed_qty[pid] = committed_qty.get(pid, 0) + r["rental_qty"]
+        committed_qty = {
+            g["rented_product_id"][0]: g["rental_qty"]
+            for g in rental_groups
+            if g.get("rented_product_id")
+        }
 
         # Products with rental services
         domain = [("rental_service_ids", "!=", False)]
@@ -137,12 +144,14 @@ class ProductProduct(models.Model):
         return products
 
     @api.model
-    def get_rental_modal_products(self, location_id=None):
+    def get_rental_modal_products(self, location_id=None, date_from=None, date_to=None):
         """Return service products with availability and pricings for the modal.
 
         Replaces 4+ separate JS RPC calls with a single one.
         Includes batch-loaded pricing data so the JS never needs
         separate pricing lookups.
+        date_from/date_to (YYYY-MM-DD) filter committed rentals to those that
+        overlap the booking period, matching sidebar availability logic.
         """
         if location_id:
             rental_in_ids = [location_id]
@@ -155,27 +164,40 @@ class ProductProduct(models.Model):
         if not rental_in_ids:
             return []
 
-        # Stock at rental_in locations
-        quants = self.env["stock.quant"].search_read(
+        # Stock at rental_in locations — aggregate in SQL
+        quant_groups = self.env["stock.quant"].read_group(
             [("location_id", "in", rental_in_ids), ("quantity", ">", 0)],
-            ["product_id", "quantity"],
+            ["product_id", "quantity:sum"],
+            ["product_id"],
         )
-        rental_in_qty = {}
-        for q in quants:
-            pid = q["product_id"][0]
-            rental_in_qty[pid] = rental_in_qty.get(pid, 0) + q["quantity"]
+        rental_in_qty = {
+            g["product_id"][0]: g["quantity"]
+            for g in quant_groups
+            if g.get("product_id")
+        }
 
-        # Committed rentals
+        # Committed rentals overlapping the selected date range — aggregate in SQL
         rental_domain = [("state", "=", "ordered")]
         if rental_in_ids:
             rental_domain.append(("out_picking_id.location_id", "in", rental_in_ids))
-        rentals = self.env["sale.rental"].search_read(
-            rental_domain, ["rented_product_id", "rental_qty"]
+        if date_from:
+            rental_domain.append(
+                ("start_datetime", "<=", (date_to or date_from) + " 23:59:59")
+            )
+        if date_to:
+            rental_domain.append(
+                ("end_datetime", ">=", (date_from or date_to) + " 00:00:00")
+            )
+        rental_groups = self.env["sale.rental"].read_group(
+            rental_domain,
+            ["rented_product_id", "rental_qty:sum"],
+            ["rented_product_id"],
         )
-        committed_qty = {}
-        for r in rentals:
-            pid = r["rented_product_id"][0]
-            committed_qty[pid] = committed_qty.get(pid, 0) + r["rental_qty"]
+        committed_qty = {
+            g["rented_product_id"][0]: g["rental_qty"]
+            for g in rental_groups
+            if g.get("rented_product_id")
+        }
 
         # Physical products with rental services
         physical_domain = [("rental_service_ids", "!=", False)]
@@ -256,17 +278,19 @@ class ProductProduct(models.Model):
         if not requested_qty:
             return []
 
-        # Stock at location
-        quants = self.env["stock.quant"].search_read(
+        # Stock at location — aggregate in SQL
+        quant_groups = self.env["stock.quant"].read_group(
             [("location_id", "=", location_id), ("quantity", ">", 0)],
-            ["product_id", "quantity"],
+            ["product_id", "quantity:sum"],
+            ["product_id"],
         )
-        rental_in_qty = {}
-        for q in quants:
-            pid = q["product_id"][0]
-            rental_in_qty[pid] = rental_in_qty.get(pid, 0) + q["quantity"]
+        rental_in_qty = {
+            g["product_id"][0]: g["quantity"]
+            for g in quant_groups
+            if g.get("product_id")
+        }
 
-        # Committed rentals overlapping date range
+        # Committed rentals overlapping date range — aggregate in SQL
         rental_domain = [
             ("state", "=", "ordered"),
             ("out_picking_id.location_id", "=", location_id),
@@ -276,25 +300,36 @@ class ProductProduct(models.Model):
         if exclude_order_id:
             rental_domain.append(("start_order_id", "!=", exclude_order_id))
 
-        rentals = self.env["sale.rental"].search_read(
-            rental_domain, ["rented_product_id", "rental_qty"]
+        rental_groups = self.env["sale.rental"].read_group(
+            rental_domain,
+            ["rented_product_id", "rental_qty:sum"],
+            ["rented_product_id"],
         )
-        committed_qty = {}
-        for r in rentals:
-            pid = r["rented_product_id"][0]
-            committed_qty[pid] = committed_qty.get(pid, 0) + r["rental_qty"]
+        committed_qty = {
+            g["rented_product_id"][0]: g["rental_qty"]
+            for g in rental_groups
+            if g.get("rented_product_id")
+        }
 
+        # Batch-load products only for those with insufficient availability
         errors = []
-        for physical_id, req_qty in requested_qty.items():
-            avail = max(
-                0,
-                rental_in_qty.get(physical_id, 0) - committed_qty.get(physical_id, 0),
-            )
-            if req_qty > avail:
-                product = self.browse(physical_id)
+        error_ids = [
+            pid
+            for pid, req_qty in requested_qty.items()
+            if req_qty > max(0, rental_in_qty.get(pid, 0) - committed_qty.get(pid, 0))
+        ]
+        if error_ids:
+            products_by_id = {p.id: p for p in self.browse(error_ids)}
+            for physical_id in error_ids:
+                req_qty = requested_qty[physical_id]
+                avail = max(
+                    0,
+                    rental_in_qty.get(physical_id, 0)
+                    - committed_qty.get(physical_id, 0),
+                )
                 errors.append(
                     "%s: requested %s, available %s"
-                    % (product.display_name, req_qty, avail)
+                    % (products_by_id[physical_id].display_name, req_qty, avail)
                 )
 
         return errors

--- a/rental_dashboard/models/product.py
+++ b/rental_dashboard/models/product.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    rental_color = fields.Integer(string="Rental Color Index", default=0)

--- a/rental_dashboard/models/product.py
+++ b/rental_dashboard/models/product.py
@@ -1,7 +1,300 @@
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ProductProduct(models.Model):
     _inherit = "product.product"
 
     rental_color = fields.Integer(string="Rental Color Index", default=0)
+
+    @api.model
+    def _get_rental_locations(self):
+        """Return rental-enabled warehouses and their location mappings."""
+        warehouses = self.env["stock.warehouse"].search_read(
+            [("rental_allowed", "=", True)],
+            ["id", "name", "rental_in_location_id", "rental_out_location_id"],
+        )
+        locations = [
+            {
+                "id": wh["rental_in_location_id"][0],
+                "name": wh["rental_in_location_id"][1],
+                "display_name": wh["name"],
+                "rental_out_location_id": wh["rental_out_location_id"][0],
+                "warehouse_id": wh["id"],
+            }
+            for wh in warehouses
+        ]
+        return warehouses, locations
+
+    @api.model
+    def get_rental_dashboard_data(self, location_id=None, date_from=None, date_to=None):
+        """Return all dashboard data in a single RPC call.
+
+        Replaces separate JS calls to load locations, rental periods, and products.
+        """
+        warehouses, locations = self._get_rental_locations()
+
+        periods = self.env["rental.period"].search_read(
+            [("active", "=", True)],
+            ["id", "name", "code", "hours_per_unit"],
+            order="sequence, id",
+        )
+
+        products = self._get_rental_products(locations, location_id, date_from, date_to)
+
+        return {
+            "locations": locations,
+            "warehouses": warehouses,
+            "rental_periods": periods,
+            "products": products,
+        }
+
+    @api.model
+    def get_rental_products(self, location_id=None, date_from=None, date_to=None):
+        """Return rental products with availability. Used on filter changes."""
+        _, locations = self._get_rental_locations()
+        return self._get_rental_products(locations, location_id, date_from, date_to)
+
+    @api.model
+    def _get_rental_products(
+        self, locations, location_id=None, date_from=None, date_to=None
+    ):
+        """Compute rental product availability at rental locations."""
+        if location_id:
+            loc = next(
+                (location for location in locations if location["id"] == location_id),
+                None,
+            )
+            rental_in_ids = [location_id] if loc else []
+            rental_out_ids = [loc["rental_out_location_id"]] if loc else []
+        else:
+            rental_in_ids = [location["id"] for location in locations]
+            rental_out_ids = [
+                location["rental_out_location_id"] for location in locations
+            ]
+
+        all_location_ids = rental_in_ids + rental_out_ids
+        if not all_location_ids:
+            return []
+
+        rental_in_set = set(rental_in_ids)
+
+        # Stock at rental locations
+        quants = self.env["stock.quant"].search_read(
+            [("location_id", "in", all_location_ids), ("quantity", ">", 0)],
+            ["product_id", "quantity", "location_id"],
+        )
+        rental_in_qty = {}
+        total_qty = {}
+        for q in quants:
+            pid = q["product_id"][0]
+            qty = q["quantity"]
+            total_qty[pid] = total_qty.get(pid, 0) + qty
+            if q["location_id"][0] in rental_in_set:
+                rental_in_qty[pid] = rental_in_qty.get(pid, 0) + qty
+
+        # Committed rental quantities
+        rental_domain = [("state", "=", "ordered")]
+        if rental_in_ids:
+            rental_domain.append(("out_picking_id.location_id", "in", rental_in_ids))
+        if date_from:
+            rental_domain.append(("start_datetime", "<=", date_to or date_from))
+        if date_to:
+            rental_domain.append(("end_datetime", ">=", date_from or date_to))
+        rentals = self.env["sale.rental"].search_read(
+            rental_domain, ["rented_product_id", "rental_qty"]
+        )
+        committed_qty = {}
+        for r in rentals:
+            pid = r["rented_product_id"][0]
+            committed_qty[pid] = committed_qty.get(pid, 0) + r["rental_qty"]
+
+        # Products with rental services
+        domain = [("rental_service_ids", "!=", False)]
+        if location_id:
+            product_ids = list(total_qty.keys())
+            if not product_ids:
+                return []
+            domain.append(("id", "in", product_ids))
+
+        products = self.search_read(
+            domain, ["id", "name", "default_code", "rental_color"]
+        )
+
+        for p in products:
+            p["qty_total"] = total_qty.get(p["id"], 0)
+            avail = max(
+                0,
+                rental_in_qty.get(p["id"], 0) - committed_qty.get(p["id"], 0),
+            )
+            p["qty_available"] = avail
+            if avail > 5:
+                p["availability_status"] = "available"
+            elif avail > 0:
+                p["availability_status"] = "low"
+            else:
+                p["availability_status"] = "unavailable"
+
+        return products
+
+    @api.model
+    def get_rental_modal_products(self, location_id=None):
+        """Return service products with availability and pricings for the modal.
+
+        Replaces 4+ separate JS RPC calls with a single one.
+        Includes batch-loaded pricing data so the JS never needs
+        separate pricing lookups.
+        """
+        if location_id:
+            rental_in_ids = [location_id]
+        else:
+            warehouses = self.env["stock.warehouse"].search_read(
+                [("rental_allowed", "=", True)], ["rental_in_location_id"]
+            )
+            rental_in_ids = [wh["rental_in_location_id"][0] for wh in warehouses]
+
+        if not rental_in_ids:
+            return []
+
+        # Stock at rental_in locations
+        quants = self.env["stock.quant"].search_read(
+            [("location_id", "in", rental_in_ids), ("quantity", ">", 0)],
+            ["product_id", "quantity"],
+        )
+        rental_in_qty = {}
+        for q in quants:
+            pid = q["product_id"][0]
+            rental_in_qty[pid] = rental_in_qty.get(pid, 0) + q["quantity"]
+
+        # Committed rentals
+        rental_domain = [("state", "=", "ordered")]
+        if rental_in_ids:
+            rental_domain.append(("out_picking_id.location_id", "in", rental_in_ids))
+        rentals = self.env["sale.rental"].search_read(
+            rental_domain, ["rented_product_id", "rental_qty"]
+        )
+        committed_qty = {}
+        for r in rentals:
+            pid = r["rented_product_id"][0]
+            committed_qty[pid] = committed_qty.get(pid, 0) + r["rental_qty"]
+
+        # Physical products with rental services
+        physical_domain = [("rental_service_ids", "!=", False)]
+        if location_id:
+            product_ids = list(rental_in_qty.keys())
+            if not product_ids:
+                return []
+            physical_domain.append(("id", "in", product_ids))
+
+        physical = self.search_read(physical_domain, ["id", "rental_service_ids"])
+        avail_map = {
+            p["id"]: max(
+                0,
+                rental_in_qty.get(p["id"], 0) - committed_qty.get(p["id"], 0),
+            )
+            for p in physical
+        }
+
+        all_service_ids = []
+        for p in physical:
+            all_service_ids.extend(p["rental_service_ids"])
+
+        if not all_service_ids:
+            return []
+
+        # Service products
+        services = self.search_read(
+            [("id", "in", all_service_ids)],
+            ["id", "name", "rented_product_id"],
+        )
+
+        # Batch load all pricings for these services
+        pricings = self.env["product.rental.pricing"].search_read(
+            [("product_id", "in", all_service_ids)],
+            ["product_id", "period_id", "price"],
+        )
+        pricing_map = {}
+        for pr in pricings:
+            pid = pr["product_id"][0]
+            pricing_map.setdefault(pid, []).append(
+                {"period_id": pr["period_id"][0], "price": pr["price"]}
+            )
+
+        for sp in services:
+            physical_id = (
+                sp["rented_product_id"][0] if sp["rented_product_id"] else None
+            )
+            sp["physicalProductId"] = physical_id
+            sp["qty_available"] = avail_map.get(physical_id, 0) if physical_id else 0
+            sp["pricings"] = pricing_map.get(sp["id"], [])
+
+        return services
+
+    @api.model
+    def check_rental_availability(
+        self, location_id, start_date, end_date, lines, exclude_order_id=None
+    ):
+        """Server-side availability check. Replaces 2 JS RPC calls with 1.
+
+        :param location_id: rental_in location ID
+        :param start_date: YYYY-MM-DD string
+        :param end_date: YYYY-MM-DD string
+        :param lines: [{'product_id': int (service), 'rental_qty': float}]
+        :param exclude_order_id: order ID to exclude (for edits)
+        :returns: list of error strings (empty = all available)
+        """
+        # Map service products to physical products
+        service_ids = [line["product_id"] for line in lines]
+        services = self.browse(service_ids)
+        requested_qty = {}
+        for line, service in zip(lines, services):
+            physical_id = service.rented_product_id.id
+            if physical_id:
+                requested_qty[physical_id] = (
+                    requested_qty.get(physical_id, 0) + line["rental_qty"]
+                )
+
+        if not requested_qty:
+            return []
+
+        # Stock at location
+        quants = self.env["stock.quant"].search_read(
+            [("location_id", "=", location_id), ("quantity", ">", 0)],
+            ["product_id", "quantity"],
+        )
+        rental_in_qty = {}
+        for q in quants:
+            pid = q["product_id"][0]
+            rental_in_qty[pid] = rental_in_qty.get(pid, 0) + q["quantity"]
+
+        # Committed rentals overlapping date range
+        rental_domain = [
+            ("state", "=", "ordered"),
+            ("out_picking_id.location_id", "=", location_id),
+            ("start_datetime", "<=", end_date + " 00:00:00"),
+            ("end_datetime", ">=", start_date + " 00:00:00"),
+        ]
+        if exclude_order_id:
+            rental_domain.append(("start_order_id", "!=", exclude_order_id))
+
+        rentals = self.env["sale.rental"].search_read(
+            rental_domain, ["rented_product_id", "rental_qty"]
+        )
+        committed_qty = {}
+        for r in rentals:
+            pid = r["rented_product_id"][0]
+            committed_qty[pid] = committed_qty.get(pid, 0) + r["rental_qty"]
+
+        errors = []
+        for physical_id, req_qty in requested_qty.items():
+            avail = max(
+                0,
+                rental_in_qty.get(physical_id, 0) - committed_qty.get(physical_id, 0),
+            )
+            if req_qty > avail:
+                product = self.browse(physical_id)
+                errors.append(
+                    "%s: requested %s, available %s"
+                    % (product.display_name, req_qty, avail)
+                )
+
+        return errors

--- a/rental_dashboard/models/sale_order_line.py
+++ b/rental_dashboard/models/sale_order_line.py
@@ -62,6 +62,7 @@ class SaleOrderLine(models.Model):
                 "product_id": line["product_id"],
                 "rental": True,
                 "rental_type": line.get("rental_type", "new_rental"),
+                "extension_rental_id": line.get("extension_rental_id") or False,
                 "rental_qty": line["rental_qty"],
                 "rental_period_id": line.get("rental_period_id"),
                 "start_datetime": line["start_datetime"],
@@ -104,6 +105,7 @@ class SaleOrderLine(models.Model):
                 "product_id": line["product_id"],
                 "rental": True,
                 "rental_type": line.get("rental_type", "new_rental"),
+                "extension_rental_id": line.get("extension_rental_id") or False,
                 "rental_qty": line["rental_qty"],
                 "rental_period_id": line.get("rental_period_id"),
                 "start_datetime": line["start_datetime"],
@@ -139,6 +141,7 @@ class SaleOrderLine(models.Model):
                 "id",
                 "product_id",
                 "rental_type",
+                "extension_rental_id",
                 "rental_period_id",
                 "rental_qty",
                 "price_unit",
@@ -155,9 +158,20 @@ class SaleOrderLine(models.Model):
             else None
         )
 
-        # Get modal products with pricings for this location
+        # Get modal products with pricings for this location, filtered by order dates
+        first_line = rental_lines[0] if rental_lines else None
+        date_from = (
+            str(first_line["start_datetime"]).split(" ")[0]
+            if first_line and first_line.get("start_datetime")
+            else None
+        )
+        date_to = (
+            str(first_line["end_datetime"]).split(" ")[0]
+            if first_line and first_line.get("end_datetime")
+            else None
+        )
         modal_products = self.env["product.product"].get_rental_modal_products(
-            location_id
+            location_id, date_from=date_from, date_to=date_to
         )
 
         return {

--- a/rental_dashboard/models/sale_order_line.py
+++ b/rental_dashboard/models/sale_order_line.py
@@ -11,18 +11,166 @@ class SaleOrderLine(models.Model):
     )
 
     @api.depends(
-        "product_id", "order_partner_id", "rental", "order_id.warehouse_id.rental_in_location_id",
+        "product_id",
+        "order_partner_id",
+        "rental",
+        "order_id.warehouse_id.rental_in_location_id",
     )
     def _compute_rental_display_name(self):
         for line in self:
-            if line.rental and line.product_id:
-                parts = []
-                parts.append("\U0001F3D7 %s" % line.product_id.display_name)
-                if line.order_id.warehouse_id and line.order_id.warehouse_id.rental_in_location_id:
-                    parts.append("\U0001F4CD %s" % line.order_id.warehouse_id.rental_in_location_id.name)
-                if line.order_partner_id:
-                    parts.append("\U0001F464 %s" % line.order_partner_id.name)
-                line.rental_display_name = " | ".join(parts)
-            else:
+            if not (line.rental and line.product_id):
                 line.rental_display_name = line.name or ""
+                continue
+            parts = ["\U0001F3D7 %s" % line.product_id.display_name]
+            loc = line.order_id.warehouse_id.rental_in_location_id
+            if loc:
+                parts.append("\U0001F4CD %s" % loc.name)
+            if line.order_partner_id:
+                parts.append("\U0001F464 %s" % line.order_partner_id.name)
+            line.rental_display_name = " | ".join(parts)
 
+    @api.model
+    def create_rental_order(self, vals):
+        """Create a rental sale order with all lines in a single RPC call.
+
+        :param vals: {
+            'partner_id': int,
+            'warehouse_id': int,
+            'lines': [{
+                'product_id': int,
+                'rental_type': str,
+                'rental_qty': float,
+                'rental_period_id': int,
+                'start_datetime': str,
+                'end_datetime': str,
+                'product_uom_qty': float,
+                'price_unit': float,
+            }]
+        }
+        :returns: order ID (int)
+        """
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": vals["partner_id"],
+                "warehouse_id": vals["warehouse_id"],
+            }
+        )
+
+        line_vals = [
+            {
+                "order_id": order.id,
+                "product_id": line["product_id"],
+                "rental": True,
+                "rental_type": line.get("rental_type", "new_rental"),
+                "rental_qty": line["rental_qty"],
+                "rental_period_id": line.get("rental_period_id"),
+                "start_datetime": line["start_datetime"],
+                "end_datetime": line["end_datetime"],
+                "product_uom_qty": line.get("product_uom_qty", line["rental_qty"]),
+                "price_unit": line.get("price_unit", 0),
+            }
+            for line in vals.get("lines", [])
+        ]
+
+        if line_vals:
+            self.create(line_vals)
+
+        return order.id
+
+    @api.model
+    def update_rental_order(self, order_id, vals):
+        """Update a rental sale order and replace its lines in a single RPC.
+
+        :param order_id: sale.order ID to update
+        :param vals: same structure as create_rental_order
+        """
+        order = self.env["sale.order"].browse(order_id)
+        order.write(
+            {
+                "partner_id": vals["partner_id"],
+                "warehouse_id": vals["warehouse_id"],
+            }
+        )
+
+        # Remove old rental lines
+        old_lines = self.search([("order_id", "=", order_id), ("rental", "=", True)])
+        if old_lines:
+            old_lines.unlink()
+
+        # Create new lines in batch
+        line_vals = [
+            {
+                "order_id": order_id,
+                "product_id": line["product_id"],
+                "rental": True,
+                "rental_type": line.get("rental_type", "new_rental"),
+                "rental_qty": line["rental_qty"],
+                "rental_period_id": line.get("rental_period_id"),
+                "start_datetime": line["start_datetime"],
+                "end_datetime": line["end_datetime"],
+                "product_uom_qty": line.get("product_uom_qty", line["rental_qty"]),
+                "price_unit": line.get("price_unit", 0),
+            }
+            for line in vals.get("lines", [])
+        ]
+
+        if line_vals:
+            self.create(line_vals)
+
+    @api.model
+    def get_rental_order_edit_data(self, so_line_id):
+        """Load all data needed to edit a rental order in a single RPC.
+
+        Returns order header, all rental lines, location, and modal products.
+
+        :param so_line_id: sale.order.line ID (the clicked calendar event)
+        :returns: dict with order, location_id, modal_products
+        """
+        line = self.browse(so_line_id)
+        if not line.exists():
+            return None
+
+        order = line.order_id
+
+        # All rental lines for this order
+        rental_lines = self.search_read(
+            [("order_id", "=", order.id), ("rental", "=", True)],
+            [
+                "id",
+                "product_id",
+                "rental_type",
+                "rental_period_id",
+                "rental_qty",
+                "price_unit",
+                "start_datetime",
+                "end_datetime",
+            ],
+        )
+
+        # Find rental_in location from warehouse
+        warehouse = order.warehouse_id
+        location_id = (
+            warehouse.rental_in_location_id.id
+            if warehouse.rental_in_location_id
+            else None
+        )
+
+        # Get modal products with pricings for this location
+        modal_products = self.env["product.product"].get_rental_modal_products(
+            location_id
+        )
+
+        return {
+            "order": {
+                "id": order.id,
+                "partner_id": [order.partner_id.id, order.partner_id.name],
+                "warehouse_id": [
+                    order.warehouse_id.id,
+                    order.warehouse_id.name,
+                ],
+                "state": order.state,
+            },
+            "lines": rental_lines,
+            "location_id": location_id,
+            "modal_products": modal_products,
+        }

--- a/rental_dashboard/models/sale_order_line.py
+++ b/rental_dashboard/models/sale_order_line.py
@@ -1,0 +1,28 @@
+from odoo import api, fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    rental_display_name = fields.Char(
+        string="Rental Display",
+        compute="_compute_rental_display_name",
+        store=True,
+    )
+
+    @api.depends(
+        "product_id", "order_partner_id", "rental", "order_id.warehouse_id.rental_in_location_id",
+    )
+    def _compute_rental_display_name(self):
+        for line in self:
+            if line.rental and line.product_id:
+                parts = []
+                parts.append("\U0001F3D7 %s" % line.product_id.display_name)
+                if line.order_id.warehouse_id and line.order_id.warehouse_id.rental_in_location_id:
+                    parts.append("\U0001F4CD %s" % line.order_id.warehouse_id.rental_in_location_id.name)
+                if line.order_partner_id:
+                    parts.append("\U0001F464 %s" % line.order_partner_id.name)
+                line.rental_display_name = " | ".join(parts)
+            else:
+                line.rental_display_name = line.name or ""
+

--- a/rental_dashboard/static/src/js/rental_dashboard.js
+++ b/rental_dashboard/static/src/js/rental_dashboard.js
@@ -1,21 +1,23 @@
 /** @odoo-module **/
 
-import {registry} from "@web/core/registry";
-import {useService} from "@web/core/utils/hooks";
 import {
     Component,
-    useState,
-    onWillStart,
     onMounted,
+    onWillStart,
     onWillUnmount,
     useRef,
+    useState,
 } from "@odoo/owl";
 import {View} from "@web/views/view";
+import {registry} from "@web/core/registry";
+import {useService} from "@web/core/utils/hooks";
 
 export class RentalDashboard extends Component {
     setup() {
         this.orm = useService("orm");
         this.action = useService("action");
+        this.notification = useService("notification");
+        this.ui = useService("ui");
         this.viewService = useService("view");
 
         this.calendarRef = useRef("calendarContainer");
@@ -23,6 +25,10 @@ export class RentalDashboard extends Component {
         this.state = useState({
             // Filters
             selectedLocation: null,
+            locationSearch: "",
+            locationResults: [],
+            locationHasMore: false,
+            locationDropdownOpen: false,
             dateFrom: null,
             dateTo: null,
             showDatePicker: false,
@@ -34,12 +40,29 @@ export class RentalDashboard extends Component {
             warehouses: [],
             products: [],
             modalProducts: [],
+            modalLocationResults: [],
+            modalLocationHasMore: false,
             customers: [],
+            customerHasMore: false,
             rentalPeriods: [],
 
             // Calendar key for re-render
             calendarKey: 0,
             viewLoaded: false,
+            filtersChanged: false,
+
+            // Applied filters — only update on applySearch / clearFilters
+            appliedLocation: null,
+            appliedDateFrom: null,
+            appliedDateTo: null,
+            appliedProducts: [],
+
+            // Date range picker calendar state
+            calendarViewYear: new Date().getFullYear(),
+            calendarViewMonth: new Date().getMonth(),
+            // "from" | "to"
+            datePickerStep: "from",
+            hoverDate: null,
 
             // Modal state
             showModal: false,
@@ -48,6 +71,7 @@ export class RentalDashboard extends Component {
             createdOrderId: null,
             modalData: {
                 locationId: null,
+                locationSearch: "",
                 customerId: null,
                 customerSearch: "",
                 startDate: null,
@@ -56,6 +80,19 @@ export class RentalDashboard extends Component {
                 lines: [],
             },
         });
+
+        // Pin env.config.getDisplayName to the base action name ("Rental Dashboard").
+        // CalendarController builds its title as `getDisplayName() + " (Month Year)"`.
+        // Without this, each navigation/remount reads the already-modified name and
+        // appends another month, producing "Rental Dashboard (Feb) (March) (Feb) ...".
+        if (this.env.config?.getDisplayName) {
+            const baseName = this.env.config.getDisplayName();
+            this.env.config.getDisplayName = () => baseName;
+        }
+
+        // Cached calendar props — rebuilt only in onMounted and applySearch so
+        // the View child never receives a new object reference from unrelated renders.
+        this._calendarPropsCache = null;
 
         // Bind event handlers once (for proper removeEventListener)
         this.onCalendarClick = this.onCalendarClick.bind(this);
@@ -72,6 +109,26 @@ export class RentalDashboard extends Component {
         this.dragStartDate = null;
         this.dragEndDate = null;
         this._isDraggingCalendar = false;
+
+        // Debounced search handlers (prevent RPC on every keystroke)
+        this._debouncedLocationSearch = this._debounce(async (search) => {
+            const {results, hasMore} = await this._searchLocations(search);
+            this.state.locationResults = results;
+            this.state.locationHasMore = hasMore;
+        });
+        this._debouncedModalLocationSearch = this._debounce(async (search) => {
+            const {results, hasMore} = await this._searchLocations(search);
+            this.state.modalLocationResults = results;
+            this.state.modalLocationHasMore = hasMore;
+        });
+        this._debouncedCustomerSearch = this._debounce(async (search) => {
+            const {results, hasMore} = await this._searchCustomers(search);
+            this.state.customers = results;
+            this.state.customerHasMore = hasMore;
+        });
+        this._debouncedRefreshCalendar = this._debounce(() => {
+            this._refreshCalendar();
+        }, 150);
 
         // ── Lifecycle ──
 
@@ -95,6 +152,7 @@ export class RentalDashboard extends Component {
             this._setupCalendarObserver();
             this._setupDialogObserver();
             this.state.viewLoaded = true;
+            this._calendarPropsCache = this._buildCalendarProps();
         });
 
         onWillUnmount(() => {
@@ -129,6 +187,17 @@ export class RentalDashboard extends Component {
             if (this.tooltipTimeout) clearTimeout(this.tooltipTimeout);
             if (this.highlightDebounce) clearTimeout(this.highlightDebounce);
         });
+    }
+
+    _debounce(fn, delay = 300) {
+        let timer = null;
+        return (...args) => {
+            if (timer) clearTimeout(timer);
+            timer = setTimeout(() => {
+                timer = null;
+                fn(...args);
+            }, delay);
+        };
     }
 
     // ── Setup helpers (extracted from onMounted for readability) ──
@@ -284,7 +353,7 @@ export class RentalDashboard extends Component {
             ev.stopPropagation();
             ev.preventDefault();
             const recordId = this._getRecordIdFromEvent(eventEl);
-            if (recordId) this.openEditModal(parseInt(recordId));
+            if (recordId) this.openEditModal(parseInt(recordId, 10));
         }
     }
 
@@ -315,7 +384,7 @@ export class RentalDashboard extends Component {
             this.orm
                 .searchRead(
                     "sale.order.line",
-                    [["id", "=", parseInt(recordId)]],
+                    [["id", "=", parseInt(recordId, 10)]],
                     [
                         "id",
                         "product_id",
@@ -408,9 +477,9 @@ export class RentalDashboard extends Component {
             "get_rental_products",
             [],
             {
-                location_id: this.state.selectedLocation,
-                date_from: this.state.dateFrom,
-                date_to: this.state.dateTo,
+                location_id: this.state.appliedLocation,
+                date_from: this.state.appliedDateFrom,
+                date_to: this.state.appliedDateTo,
             }
         );
         this.state.products = products;
@@ -423,7 +492,11 @@ export class RentalDashboard extends Component {
             "product.product",
             "get_rental_modal_products",
             [],
-            {location_id: this.state.modalData.locationId}
+            {
+                location_id: this.state.modalData.locationId,
+                date_from: this.state.modalData.startDate || null,
+                date_to: this.state.modalData.endDate || null,
+            }
         );
     }
 
@@ -435,50 +508,123 @@ export class RentalDashboard extends Component {
         return products;
     }
 
-    get calendarDomain() {
+    _buildCalendarProps() {
         const domain = [
             ["rental", "=", true],
             ["state", "not in", ["cancel"]],
         ];
-
-        if (this.state.selectedLocation) {
+        if (this.state.appliedLocation) {
             const loc = this.state.locations.find(
-                (l) => l.id === this.state.selectedLocation
+                (l) => l.id === this.state.appliedLocation
             );
             if (loc) domain.push(["order_id.warehouse_id", "=", loc.warehouse_id]);
         }
-        if (this.state.dateFrom)
-            domain.push(["end_datetime", ">=", this.state.dateFrom]);
-        if (this.state.dateTo) domain.push(["start_datetime", "<=", this.state.dateTo]);
-        if (this.state.selectedProducts.length > 0) {
+        if (this.state.appliedDateFrom)
+            domain.push(["end_datetime", ">=", this.state.appliedDateFrom]);
+        if (this.state.appliedDateTo)
+            domain.push(["start_datetime", "<=", this.state.appliedDateTo]);
+        if (this.state.appliedProducts.length > 0) {
             domain.push([
                 "product_id.rented_product_id",
                 "in",
-                this.state.selectedProducts,
+                this.state.appliedProducts,
             ]);
         }
-        return domain;
-    }
-
-    get calendarProps() {
-        if (!this.state.viewLoaded) return null;
         return {
             resModel: "sale.order.line",
             type: "calendar",
-            domain: this.calendarDomain,
+            domain,
             context: this.props.context || {},
             display: {},
         };
     }
 
+    get calendarProps() {
+        if (!this.state.viewLoaded) return null;
+        return this._calendarPropsCache;
+    }
+
     // ── Filter actions ──
 
-    async onLocationChange(ev) {
-        const value = ev.target.value;
-        this.state.selectedLocation = value ? parseInt(value) : null;
+    async _searchLocations(search, limit = 20) {
+        const domain = [["rental_allowed", "=", true]];
+        if (search) domain.push(["rental_in_location_id.name", "ilike", search]);
+        const warehouses = await this.orm.searchRead(
+            "stock.warehouse",
+            domain,
+            ["id", "name", "rental_in_location_id", "rental_out_location_id"],
+            {limit}
+        );
+        const results = warehouses
+            .filter((wh) => wh.rental_in_location_id)
+            .map((wh) => ({
+                id: wh.rental_in_location_id[0],
+                name: wh.rental_in_location_id[1],
+                display_name: wh.name,
+                warehouse_id: wh.id,
+                rental_out_location_id: wh.rental_out_location_id
+                    ? wh.rental_out_location_id[0]
+                    : null,
+            }));
+        return {results, hasMore: warehouses.length === limit};
+    }
+
+    async _searchCustomers(search, limit = 20) {
+        const domain = search
+            ? ["|", ["name", "ilike", search], ["email", "ilike", search]]
+            : [["customer_rank", ">", 0]];
+        const partners = await this.orm.searchRead(
+            "res.partner",
+            domain,
+            ["id", "name", "email"],
+            {limit}
+        );
+        return {results: partners, hasMore: partners.length === limit};
+    }
+
+    onLocationSearchInput(ev) {
+        const search = ev.target.value;
+        this.state.locationSearch = search;
+        if (!search) {
+            this.state.selectedLocation = null;
+            this.state.selectedProducts = [];
+            this.state.filtersChanged = true;
+        }
+        this._debouncedLocationSearch(search);
+    }
+
+    async onLocationSearchFocus() {
+        this.state.locationDropdownOpen = true;
+        if (this.state.locationResults.length === 0) {
+            const {results, hasMore} = await this._searchLocations(
+                this.state.locationSearch
+            );
+            this.state.locationResults = results;
+            this.state.locationHasMore = hasMore;
+        }
+    }
+
+    onLocationSearchBlur() {
+        // Delay so a click on a dropdown item registers before the dropdown closes
+        setTimeout(() => {
+            this.state.locationDropdownOpen = false;
+        }, 200);
+    }
+
+    async loadMoreLocations() {
+        const {results} = await this._searchLocations(this.state.locationSearch, 100);
+        this.state.locationResults = results;
+        this.state.locationHasMore = false;
+    }
+
+    selectLocation(loc) {
+        this.state.selectedLocation = loc.id;
+        this.state.locationSearch = loc.name;
+        this.state.locationResults = [];
+        this.state.locationHasMore = false;
+        this.state.locationDropdownOpen = false;
         this.state.selectedProducts = [];
-        await this.loadProducts();
-        this._refreshCalendar();
+        this.state.filtersChanged = true;
     }
 
     onShowAvailableChange(ev) {
@@ -492,52 +638,193 @@ export class RentalDashboard extends Component {
         } else {
             this.state.selectedProducts.push(productId);
         }
-        this._refreshCalendar();
+        this.state.filtersChanged = true;
     }
 
     isProductSelected(productId) {
         return this.state.selectedProducts.includes(productId);
     }
 
-    async clearFilters() {
+    clearFilters() {
         this.state.selectedLocation = null;
+        this.state.locationSearch = "";
+        this.state.locationResults = [];
+        this.state.locationHasMore = false;
+        this.state.locationDropdownOpen = false;
         this.state.dateFrom = null;
         this.state.dateTo = null;
         this.state.showDatePicker = false;
+        this.state.datePickerStep = "from";
+        this.state.hoverDate = null;
         this.state.showAvailableOnly = false;
         this.state.selectedProducts = [];
+        this.state.filtersChanged = true;
+    }
+
+    async applySearch() {
+        this.state.appliedLocation = this.state.selectedLocation;
+        this.state.appliedDateFrom = this.state.dateFrom;
+        this.state.appliedDateTo = this.state.dateTo;
+        this.state.appliedProducts = [...this.state.selectedProducts];
+        this.state.filtersChanged = false;
+        this._calendarPropsCache = this._buildCalendarProps();
         await this.loadProducts();
-        this._refreshCalendar();
+        this._debouncedRefreshCalendar();
+        setTimeout(() => this.applyDateRangeHighlight(), 500);
     }
 
     // ── Date filter ──
 
     toggleDatePicker() {
+        if (!this.state.showDatePicker) {
+            const ref = this.state.dateFrom || null;
+            const d = ref ? new Date(ref + "T00:00:00") : new Date();
+            this.state.calendarViewYear = d.getFullYear();
+            this.state.calendarViewMonth = d.getMonth();
+            this.state.datePickerStep = "from";
+            this.state.hoverDate = null;
+        }
         this.state.showDatePicker = !this.state.showDatePicker;
+    }
+
+    prevMonth() {
+        if (this.state.calendarViewMonth === 0) {
+            this.state.calendarViewMonth = 11;
+            this.state.calendarViewYear--;
+        } else {
+            this.state.calendarViewMonth--;
+        }
+    }
+
+    nextMonth() {
+        if (this.state.calendarViewMonth === 11) {
+            this.state.calendarViewMonth = 0;
+            this.state.calendarViewYear++;
+        } else {
+            this.state.calendarViewMonth++;
+        }
+    }
+
+    getCalendarMonthLabel() {
+        const months = [
+            "January",
+            "February",
+            "March",
+            "April",
+            "May",
+            "June",
+            "July",
+            "August",
+            "September",
+            "October",
+            "November",
+            "December",
+        ];
+        return `${months[this.state.calendarViewMonth]} ${this.state.calendarViewYear}`;
+    }
+
+    getCalendarDays() {
+        const year = this.state.calendarViewYear;
+        const month = this.state.calendarViewMonth;
+        const firstDay = new Date(year, month, 1).getDay();
+        const daysInMonth = new Date(year, month + 1, 0).getDate();
+        const cells = [];
+        for (let i = 0; i < firstDay; i++) {
+            cells.push({key: `empty-${i}`, day: null, date: null});
+        }
+        for (let d = 1; d <= daysInMonth; d++) {
+            const dateStr = `${year}-${String(month + 1).padStart(2, "0")}-${String(
+                d
+            ).padStart(2, "0")}`;
+            cells.push({key: dateStr, day: d, date: dateStr});
+        }
+        return cells;
+    }
+
+    _applyRangeClasses(classes, date, from, to) {
+        if (from && to) {
+            if (date >= from && date <= to) classes.push("rdp-in-range");
+            if (date === from) classes.push("rdp-range-start");
+            if (date === to) classes.push("rdp-range-end");
+        } else if (from && !to) {
+            if (date === from)
+                classes.push("rdp-in-range", "rdp-range-start", "rdp-range-end");
+        }
+    }
+
+    _applyHoverClasses(classes, date, from, to, hover, step) {
+        if (step !== "to" || !from || !hover || to) return;
+        const start = from <= hover ? from : hover;
+        const end = from <= hover ? hover : from;
+        if (date >= start && date <= end) classes.push("rdp-hover-range");
+        if (date === start) classes.push("rdp-hover-start");
+        if (date === end) classes.push("rdp-hover-end");
+    }
+
+    getCalendarDayClass(cell) {
+        if (!cell.date) return "rdp-cell rdp-empty";
+        const classes = ["rdp-cell", "rdp-day"];
+        const {
+            dateFrom: from,
+            dateTo: to,
+            hoverDate: hover,
+            datePickerStep: step,
+        } = this.state;
+        const date = cell.date;
+        this._applyRangeClasses(classes, date, from, to);
+        this._applyHoverClasses(classes, date, from, to, hover, step);
+        return classes.join(" ");
+    }
+
+    onCalendarDayClick(cell) {
+        if (!cell.date) return;
+        if (this.state.datePickerStep === "from") {
+            this.state.dateFrom = cell.date;
+            this.state.dateTo = null;
+            this.state.hoverDate = null;
+            this.state.datePickerStep = "to";
+            this.state.filtersChanged = true;
+        } else {
+            if (cell.date < this.state.dateFrom) {
+                this.state.dateTo = this.state.dateFrom;
+                this.state.dateFrom = cell.date;
+            } else {
+                this.state.dateTo = cell.date;
+            }
+            this.state.datePickerStep = "from";
+            this.state.hoverDate = null;
+            this.state.showDatePicker = false;
+            this.state.filtersChanged = true;
+        }
+    }
+
+    onCalendarDayHover(cell) {
+        if (this.state.datePickerStep === "to") {
+            this.state.hoverDate = cell.date;
+        }
     }
 
     onDateFromChange(ev) {
         this.state.dateFrom = ev.target.value || null;
+        this.state.filtersChanged = true;
     }
 
     onDateToChange(ev) {
         this.state.dateTo = ev.target.value || null;
+        this.state.filtersChanged = true;
     }
 
-    async applyDateFilter() {
+    applyDateFilter() {
         this.state.showDatePicker = false;
-        this._refreshCalendar();
-        await this.loadProducts();
-        setTimeout(() => this.applyDateRangeHighlight(), 500);
     }
 
-    async clearDateFilter() {
+    clearDateFilter() {
         this.state.dateFrom = null;
         this.state.dateTo = null;
         this.state.showDatePicker = false;
-        this._refreshCalendar();
-        await this.loadProducts();
-        this.applyDateRangeHighlight();
+        this.state.datePickerStep = "from";
+        this.state.hoverDate = null;
+        this.state.filtersChanged = true;
     }
 
     applyDateRangeHighlight() {
@@ -574,13 +861,17 @@ export class RentalDashboard extends Component {
     }
 
     formatDateRange() {
-        if (!this.state.dateFrom || !this.state.dateTo) return "";
-        const from = new Date(this.state.dateFrom);
-        const to = new Date(this.state.dateTo);
-        const diffDays = Math.ceil(Math.abs(to - from) / (1000 * 60 * 60 * 24)) + 1;
-        const fmt = (d) =>
-            `${d.getMonth() + 1}/${d.getDate()}/${String(d.getFullYear()).slice(-2)}`;
-        return `${fmt(from)} - ${fmt(to)} (${diffDays} days)`;
+        const fmt = (dateStr) => {
+            const d = new Date(dateStr + "T00:00:00");
+            const m = String(d.getMonth() + 1).padStart(2, "0");
+            const day = String(d.getDate()).padStart(2, "0");
+            return `${m}/${day}/${d.getFullYear()}`;
+        };
+        if (this.state.dateFrom && this.state.dateTo) {
+            return `${fmt(this.state.dateFrom)} - ${fmt(this.state.dateTo)}`;
+        }
+        if (this.state.dateFrom) return fmt(this.state.dateFrom);
+        return "";
     }
 
     // ── Calendar helpers ──
@@ -595,8 +886,12 @@ export class RentalDashboard extends Component {
     async openCreateModal() {
         this.state.modalMode = "create";
         this.state.editingOrderId = null;
+        const selectedLoc = this.state.locations.find(
+            (l) => l.id === this.state.selectedLocation
+        );
         this.state.modalData = {
             locationId: this.state.selectedLocation,
+            locationSearch: selectedLoc ? selectedLoc.name : "",
             customerId: null,
             customerSearch: "",
             startDate: this.state.dateFrom || this._formatDateForInput(new Date()),
@@ -627,6 +922,8 @@ export class RentalDashboard extends Component {
                 lines.push({
                     id: Date.now() + Math.random(),
                     productId: service.id,
+                    productSearch: service.name,
+                    productResults: [],
                     rentalType: "new_rental",
                     rentalPeriodId,
                     availablePeriodIds,
@@ -646,8 +943,12 @@ export class RentalDashboard extends Component {
     async openCreateModalWithDates(startDate, endDate) {
         this.state.modalMode = "create";
         this.state.editingOrderId = null;
+        const selectedLoc = this.state.locations.find(
+            (l) => l.id === this.state.selectedLocation
+        );
         this.state.modalData = {
             locationId: this.state.selectedLocation,
+            locationSearch: selectedLoc ? selectedLoc.name : "",
             customerId: null,
             customerSearch: "",
             startDate,
@@ -687,6 +988,7 @@ export class RentalDashboard extends Component {
             this.state.editingOrderId = order.id;
             this.state.modalData = {
                 locationId: location_id,
+                locationSearch: loc ? loc.name : "",
                 customerId: order.partner_id[0],
                 customerSearch: order.partner_id[1],
                 startDate: firstLine?.start_datetime
@@ -712,7 +1014,20 @@ export class RentalDashboard extends Component {
                 return {
                     id: line.id,
                     productId: serviceProductId,
+                    productSearch: modalProduct
+                        ? modalProduct.name
+                        : line.product_id[1] || "",
+                    productResults: [],
+                    productHasMore: false,
                     rentalType: line.rental_type,
+                    extensionRentalId: line.extension_rental_id
+                        ? line.extension_rental_id[0]
+                        : null,
+                    extensionRentalSearch: line.extension_rental_id
+                        ? line.extension_rental_id[1]
+                        : "",
+                    extensionRentalResults: [],
+                    extensionRentalHasMore: false,
                     rentalPeriodId: line.rental_period_id
                         ? line.rental_period_id[0]
                         : null,
@@ -729,7 +1044,6 @@ export class RentalDashboard extends Component {
             this.state.showModal = true;
         } catch (error) {
             console.error("Error loading sale order:", error);
-            alert("Error loading rental data. Please try again.");
         }
     }
 
@@ -739,7 +1053,14 @@ export class RentalDashboard extends Component {
         return {
             id: Date.now() + Math.random(),
             productId: null,
+            productSearch: "",
+            productResults: [],
+            productHasMore: false,
             rentalType: "new_rental",
+            extensionRentalId: null,
+            extensionRentalSearch: "",
+            extensionRentalResults: [],
+            extensionRentalHasMore: false,
             rentalPeriodId: null,
             availablePeriodIds: [],
             rentalQty: 1,
@@ -753,56 +1074,70 @@ export class RentalDashboard extends Component {
         this.state.createdOrderId = null;
     }
 
-    openEditingOrder() {
+    async openEditingOrder() {
         if (!this.state.editingOrderId) return;
-        this.action.doAction({
-            type: "ir.actions.act_window",
-            res_model: "sale.order",
-            res_id: this.state.editingOrderId,
-            views: [[false, "form"]],
-            target: "current",
-        });
+        this.ui.block();
+        try {
+            await this.action.doAction({
+                type: "ir.actions.act_window",
+                res_model: "sale.order",
+                res_id: this.state.editingOrderId,
+                views: [[false, "form"]],
+                target: "current",
+            });
+        } finally {
+            this.ui.unblock();
+        }
     }
 
     async confirmEditingOrder() {
         if (!this.state.editingOrderId) return;
+        this.ui.block();
         try {
             await this.orm.call("sale.order", "action_confirm", [
                 this.state.editingOrderId,
             ]);
             this.state.modalData.state = "sale";
-            this._refreshCalendar();
+            this._debouncedRefreshCalendar();
             await this.loadProducts();
         } catch (error) {
             console.error("Error confirming order:", error);
-            alert("Error confirming order. Please try again.");
+        } finally {
+            this.ui.unblock();
         }
     }
 
-    openCreatedOrder() {
+    async openCreatedOrder() {
         if (!this.state.createdOrderId) return;
-        this.action.doAction({
-            type: "ir.actions.act_window",
-            res_model: "sale.order",
-            res_id: this.state.createdOrderId,
-            views: [[false, "form"]],
-            target: "current",
-        });
+        this.ui.block();
+        try {
+            await this.action.doAction({
+                type: "ir.actions.act_window",
+                res_model: "sale.order",
+                res_id: this.state.createdOrderId,
+                views: [[false, "form"]],
+                target: "current",
+            });
+        } finally {
+            this.ui.unblock();
+        }
     }
 
     async confirmCreatedOrder() {
         if (!this.state.createdOrderId) return;
+        this.ui.block();
         try {
             await this.orm.call("sale.order", "action_confirm", [
                 this.state.createdOrderId,
             ]);
             this.state.showModal = false;
             this.state.createdOrderId = null;
-            this._refreshCalendar();
+            this._debouncedRefreshCalendar();
             await this.loadProducts();
         } catch (error) {
             console.error("Error confirming order:", error);
-            alert("Error confirming order. Please try again.");
+        } finally {
+            this.ui.unblock();
         }
     }
 
@@ -812,32 +1147,71 @@ export class RentalDashboard extends Component {
 
     // ── Modal: field handlers ──
 
-    async onModalLocationChange(ev) {
-        this.state.modalData.locationId = ev.target.value
-            ? parseInt(ev.target.value)
-            : null;
-        await this.loadModalProducts();
+    onModalLocationSearchInput(ev) {
+        const search = ev.target.value;
+        this.state.modalData.locationSearch = search;
+        if (!search) this.state.modalData.locationId = null;
+        this._debouncedModalLocationSearch(search);
     }
 
-    async onCustomerSearch(ev) {
+    async onModalLocationSearchFocus() {
+        if (this.state.modalLocationResults.length === 0) {
+            const {results, hasMore} = await this._searchLocations(
+                this.state.modalData.locationSearch
+            );
+            this.state.modalLocationResults = results;
+            this.state.modalLocationHasMore = hasMore;
+        }
+    }
+
+    async loadMoreModalLocations() {
+        const {results} = await this._searchLocations(
+            this.state.modalData.locationSearch,
+            100
+        );
+        this.state.modalLocationResults = results;
+        this.state.modalLocationHasMore = false;
+    }
+
+    selectModalLocation(loc) {
+        this.state.modalData.locationId = loc.id;
+        this.state.modalData.locationSearch = loc.name;
+        this.state.modalLocationResults = [];
+        this.state.modalLocationHasMore = false;
+        this.loadModalProducts();
+    }
+
+    async onCustomerSearchFocus() {
+        if (this.state.customers.length === 0) {
+            const {results, hasMore} = await this._searchCustomers(
+                this.state.modalData.customerSearch
+            );
+            this.state.customers = results;
+            this.state.customerHasMore = hasMore;
+        }
+    }
+
+    onCustomerSearch(ev) {
         const search = ev.target.value;
         this.state.modalData.customerSearch = search;
-        if (search.length >= 2) {
-            this.state.customers = await this.orm.searchRead(
-                "res.partner",
-                ["|", ["name", "ilike", search], ["email", "ilike", search]],
-                ["id", "name", "email"],
-                {limit: 10}
-            );
-        } else {
-            this.state.customers = [];
-        }
+        if (!search) this.state.modalData.customerId = null;
+        this._debouncedCustomerSearch(search);
+    }
+
+    async loadMoreCustomers() {
+        const {results} = await this._searchCustomers(
+            this.state.modalData.customerSearch,
+            100
+        );
+        this.state.customers = results;
+        this.state.customerHasMore = false;
     }
 
     selectCustomer(customer) {
         this.state.modalData.customerId = customer.id;
         this.state.modalData.customerSearch = customer.name;
         this.state.customers = [];
+        this.state.customerHasMore = false;
     }
 
     onModalStartDateChange(ev) {
@@ -850,12 +1224,12 @@ export class RentalDashboard extends Component {
 
     // ── Modal: line handlers (now synchronous — no RPC calls) ──
 
-    onLineProductChange(line, ev) {
-        const productId = ev.target.value ? parseInt(ev.target.value) : null;
+    _applyLineProduct(line, productId) {
         line.productId = productId;
         line.availablePeriodIds = [];
         line.rentalPeriodId = null;
         line.priceUnit = 0;
+        line.available = 0;
 
         if (productId) {
             const product = this.state.modalProducts.find((p) => p.id === productId);
@@ -873,6 +1247,48 @@ export class RentalDashboard extends Component {
         }
     }
 
+    _filterLineProducts(line, search, limit = 20) {
+        const all = search
+            ? this.state.modalProducts.filter((p) =>
+                  p.name.toLowerCase().includes(search.toLowerCase())
+              )
+            : this.state.modalProducts;
+        return {results: all.slice(0, limit), hasMore: all.length > limit};
+    }
+
+    onLineProductSearchInput(line, ev) {
+        const search = ev.target.value;
+        line.productSearch = search;
+        if (!search) this._applyLineProduct(line, null);
+        const {results, hasMore} = this._filterLineProducts(line, search);
+        line.productResults = results;
+        line.productHasMore = hasMore;
+    }
+
+    onLineProductSearchFocus(line) {
+        if (line.productResults.length === 0) {
+            const {results, hasMore} = this._filterLineProducts(
+                line,
+                line.productSearch
+            );
+            line.productResults = results;
+            line.productHasMore = hasMore;
+        }
+    }
+
+    loadMoreLineProducts(line) {
+        const {results} = this._filterLineProducts(line, line.productSearch, 100);
+        line.productResults = results;
+        line.productHasMore = false;
+    }
+
+    selectLineProduct(line, product) {
+        line.productSearch = product.name;
+        line.productResults = [];
+        line.productHasMore = false;
+        this._applyLineProduct(line, product.id);
+    }
+
     getLineAvailablePeriods(line) {
         if (!line.availablePeriodIds || line.availablePeriodIds.length === 0) return [];
         return this.state.rentalPeriods.filter((p) =>
@@ -882,10 +1298,76 @@ export class RentalDashboard extends Component {
 
     onLineRentalTypeChange(line, ev) {
         line.rentalType = ev.target.value || "new_rental";
+        // Clear extension selection when switching away from extension type
+        if (line.rentalType !== "rental_extension") {
+            line.extensionRentalId = null;
+            line.extensionRentalSearch = "";
+            line.extensionRentalResults = [];
+        }
+    }
+
+    // ── Extension rental typeahead ──
+
+    async _searchRentals(productId, search, limit = 20) {
+        const domain = [
+            ["rental_product_id", "=", productId],
+            ["state", "in", ["ordered", "out"]],
+        ];
+        const results = await this.orm.call(
+            "sale.rental",
+            "name_search",
+            [search || ""],
+            {
+                args: domain,
+                limit: limit + 1,
+            }
+        );
+        const hasMore = results.length > limit;
+        return {
+            results: results.slice(0, limit).map(([id, name]) => ({id, name})),
+            hasMore,
+        };
+    }
+
+    async onLineExtensionSearchFocus(line) {
+        if (!line.productId) return;
+        const {results, hasMore} = await this._searchRentals(line.productId, "");
+        line.extensionRentalResults = results;
+        line.extensionRentalHasMore = hasMore;
+    }
+
+    async onLineExtensionSearchInput(line, ev) {
+        const search = ev.target.value;
+        line.extensionRentalSearch = search;
+        if (!search) {
+            line.extensionRentalId = null;
+        }
+        if (!line.productId) return;
+        const {results, hasMore} = await this._searchRentals(line.productId, search);
+        line.extensionRentalResults = results;
+        line.extensionRentalHasMore = hasMore;
+    }
+
+    selectLineExtension(line, rental) {
+        line.extensionRentalId = rental.id;
+        line.extensionRentalSearch = rental.name;
+        line.extensionRentalResults = [];
+        line.extensionRentalHasMore = false;
+    }
+
+    async loadMoreLineExtensions(line) {
+        if (!line.productId) return;
+        const {results, hasMore} = await this._searchRentals(
+            line.productId,
+            line.extensionRentalSearch,
+            100
+        );
+        line.extensionRentalResults = results;
+        line.extensionRentalHasMore = hasMore;
     }
 
     onLineRentalPeriodChange(line, ev) {
-        line.rentalPeriodId = ev.target.value ? parseInt(ev.target.value) : null;
+        line.rentalPeriodId = ev.target.value ? parseInt(ev.target.value, 10) : null;
         if (line.productId && line.rentalPeriodId) {
             line.priceUnit = this._computePriceUnit(
                 line.productId,
@@ -969,64 +1451,70 @@ export class RentalDashboard extends Component {
         const data = this.state.modalData;
 
         if (!data.locationId) {
-            alert("Please select a location");
+            this.notification.add("Please select a location", {type: "warning"});
             return;
         }
         if (!data.customerId) {
-            alert("Please select a customer");
+            this.notification.add("Please select a customer", {type: "warning"});
             return;
         }
         if (!data.startDate || !data.endDate) {
-            alert("Please select start and end dates");
+            this.notification.add("Please select start and end dates", {
+                type: "warning",
+            });
             return;
         }
 
         const validLines = data.lines.filter((l) => l.productId && l.rentalQty > 0);
         if (validLines.length === 0) {
-            alert("Please add at least one equipment with a rental service configured");
+            this.notification.add(
+                "Please add at least one equipment with a rental service configured",
+                {type: "warning"}
+            );
             return;
         }
 
         const loc = this.state.locations.find((l) => l.id === data.locationId);
         if (!loc) {
-            alert("Invalid location");
-            return;
-        }
-
-        // Server-side availability check (1 RPC replaces 2)
-        const availErrors = await this.orm.call(
-            "product.product",
-            "check_rental_availability",
-            [
-                data.locationId,
-                data.startDate,
-                data.endDate,
-                validLines.map((l) => ({
-                    product_id: l.productId,
-                    rental_qty: l.rentalQty,
-                })),
-                this.state.modalMode === "edit" ? this.state.editingOrderId : null,
-            ]
-        );
-        if (availErrors.length > 0) {
-            alert("Insufficient availability:\n\n" + availErrors.join("\n"));
+            this.notification.add("Invalid location", {type: "warning"});
             return;
         }
 
         const startDatetime = data.startDate + " 00:00:00";
         const endDatetime = data.endDate + " 00:00:00";
-        const numberOfDays = this._getNumberOfDays();
+        const diffHours = this._getDiffHours();
 
-        const lineVals = validLines.map((line) => ({
-            product_id: line.productId,
-            rental_type: line.rentalType,
-            rental_qty: line.rentalQty,
-            rental_period_id: line.rentalPeriodId,
-            start_datetime: startDatetime,
-            end_datetime: endDatetime,
-            product_uom_qty: line.rentalQty * numberOfDays,
-            price_unit: line.priceUnit,
-        }));
+        const lineVals = validLines.map((line) => {
+            // Mirror Python's formula (sale_order.py line 145):
+            //   product_uom_qty = rental_qty * number_of_days
+            // where number_of_days = duration * hours_per_unit / 24
+            // and duration is stored with digits="Product Unit of Measure" (2 dp).
+            // e.g. 8 days / weekly (168 h):   duration=1.14, number_of_days=7.98
+            // e.g. 28 days / monthly (730 h): duration=0.92, number_of_days=27.9833...
+            const period = this.state.rentalPeriods.find(
+                (p) => p.id === line.rentalPeriodId
+            );
+            const hoursPerUnit = period ? period.hours_per_unit : 24;
+            // "Product Unit of Measure" precision
+            const duration = parseFloat((diffHours / hoursPerUnit).toFixed(2));
+            const numberOfDays = (duration * hoursPerUnit) / 24;
+            // Exact, no extra rounding — matches Python line 145
+            const uomQty = line.rentalQty * numberOfDays;
+            return {
+                product_id: line.productId,
+                rental_type: line.rentalType,
+                extension_rental_id:
+                    line.rentalType === "rental_extension"
+                        ? line.extensionRentalId || false
+                        : false,
+                rental_qty: line.rentalQty,
+                rental_period_id: line.rentalPeriodId,
+                start_datetime: startDatetime,
+                end_datetime: endDatetime,
+                product_uom_qty: uomQty,
+                price_unit: line.priceUnit,
+            };
+        });
 
         const orderVals = {
             partner_id: data.customerId,
@@ -1034,7 +1522,31 @@ export class RentalDashboard extends Component {
             lines: lineVals,
         };
 
+        this.ui.block();
         try {
+            // Server-side availability check (1 RPC replaces 2)
+            const availErrors = await this.orm.call(
+                "product.product",
+                "check_rental_availability",
+                [
+                    data.locationId,
+                    data.startDate,
+                    data.endDate,
+                    validLines.map((l) => ({
+                        product_id: l.productId,
+                        rental_qty: l.rentalQty,
+                    })),
+                    this.state.modalMode === "edit" ? this.state.editingOrderId : null,
+                ]
+            );
+            if (availErrors.length > 0) {
+                this.notification.add(
+                    "Insufficient availability:\n\n" + availErrors.join("\n"),
+                    {type: "warning"}
+                );
+                return;
+            }
+
             if (this.state.modalMode === "edit" && this.state.editingOrderId) {
                 // Single RPC replaces N+3 calls
                 await this.orm.call("sale.order.line", "update_rental_order", [
@@ -1051,7 +1563,7 @@ export class RentalDashboard extends Component {
                 this.state.createdOrderId = orderId;
             }
 
-            this._refreshCalendar();
+            this._debouncedRefreshCalendar();
             await this.loadProducts();
 
             if (this.state.modalMode === "create" && this.state.createdOrderId) {
@@ -1061,7 +1573,8 @@ export class RentalDashboard extends Component {
             }
         } catch (error) {
             console.error("Error saving rental:", error);
-            alert("Error saving rental. Please try again.");
+        } finally {
+            this.ui.unblock();
         }
     }
 
@@ -1102,15 +1615,15 @@ export class RentalDashboard extends Component {
         return `background-color: ${colors[product.rental_color || 0]};`;
     }
 
-    getStatusBadgeClass(state) {
-        const classes = {
-            draft: "bg-secondary",
-            sent: "bg-info",
-            sale: "bg-primary",
-            done: "bg-success",
-            cancel: "bg-danger",
+    getStatusBadgeStyle(state) {
+        const styles = {
+            draft: "background-color:#e9ecef;color:#495057;",
+            sent: "background-color:#cff4fc;color:#055160;",
+            sale: "background-color:#d1e7dd;color:#0f5132;",
+            done: "background-color:#198754;color:#ffffff;",
+            cancel: "background-color:#f8d7da;color:#842029;",
         };
-        return classes[state] || "bg-secondary";
+        return styles[state] || "background-color:#dee2e6;color:#212529;";
     }
 
     getStatusLabel(state) {
@@ -1122,20 +1635,6 @@ export class RentalDashboard extends Component {
             cancel: "Cancelled",
         };
         return labels[state] || state;
-    }
-
-    async openCalendar() {
-        this.action.doAction({
-            type: "ir.actions.act_window",
-            name: "Rental Calendar",
-            res_model: "sale.order.line",
-            views: [
-                [false, "calendar"],
-                [false, "form"],
-            ],
-            target: "current",
-            domain: [["rental", "=", true]],
-        });
     }
 }
 

--- a/rental_dashboard/static/src/js/rental_dashboard.js
+++ b/rental_dashboard/static/src/js/rental_dashboard.js
@@ -1,0 +1,1410 @@
+/** @odoo-module **/
+
+import {registry} from "@web/core/registry";
+import {useService} from "@web/core/utils/hooks";
+import {Component, useState, onWillStart, onMounted, onWillUnmount, useRef} from "@odoo/owl";
+import {View} from "@web/views/view";
+
+export class RentalDashboard extends Component {
+    setup() {
+        this.orm = useService("orm");
+        this.action = useService("action");
+        this.viewService = useService("view");
+
+        this.calendarRef = useRef("calendarContainer");
+
+        this.state = useState({
+            // Filters
+            selectedLocation: null,
+            dateFrom: null,
+            dateTo: null,
+            showDatePicker: false,
+            showAvailableOnly: false,
+            selectedProducts: [],
+
+            // Data
+            locations: [],
+            warehouses: [],
+            products: [],
+            modalProducts: [], // Products filtered by modal location
+            customers: [],
+            rentalPeriods: [], // rental.period records
+
+            // Calendar key for re-render
+            calendarKey: 0,
+            viewLoaded: false,
+
+            // Modal state
+            showModal: false,
+            modalMode: 'create', // 'create', 'edit', or 'created'
+            editingOrderId: null,
+            createdOrderId: null,
+            modalData: {
+                locationId: null,
+                customerId: null,
+                customerSearch: '',
+                startDate: null,
+                endDate: null,
+                state: null,
+                lines: [],
+            },
+
+        });
+
+        // Bind event handlers
+        this.onCalendarClick = this.onCalendarClick.bind(this);
+        this.onEventMouseOver = this.onEventMouseOver.bind(this);
+        this.onEventMouseOut = this.onEventMouseOut.bind(this);
+
+        // Tooltip tracking (plain DOM, not OWL state)
+        this.tooltipTimeout = null;
+        this.currentHoveredEventId = null;
+        this.tooltipEl = null;
+
+        // Track calendar cell drag for date range selection
+        this.dragStartDate = null;
+        this.dragEndDate = null;
+
+        onWillStart(async () => {
+            await this.loadLocations();
+            await this.loadRentalPeriods();
+            await this.loadProducts();
+        });
+
+        onMounted(() => {
+            if (this.calendarRef.el) {
+                this.calendarRef.el.addEventListener('click', this.onCalendarClick, true);
+                this.calendarRef.el.addEventListener('mouseover', this.onEventMouseOver);
+                this.calendarRef.el.addEventListener('mouseout', this.onEventMouseOut);
+
+                // Track drag selection on calendar cells
+                // Use elementsFromPoint to see through FC event harness overlays
+                this.calendarRef.el.addEventListener('mousedown', (ev) => {
+                    const elements = document.elementsFromPoint(ev.clientX, ev.clientY);
+                    // Skip if clicking directly on a calendar event
+                    if (elements.some(el => el.classList && el.classList.contains('fc-event') ||
+                                            el.closest && el.closest('.fc-event'))) return;
+                    // Find the day cell underneath
+                    let date = null;
+                    for (const el of elements) {
+                        if (el.hasAttribute && el.hasAttribute('data-date')) {
+                            date = el.getAttribute('data-date');
+                            break;
+                        }
+                    }
+                    if (date) {
+                        this.dragStartDate = date;
+                        this.dragEndDate = date;
+                        this._isDraggingCalendar = true;
+                    }
+                });
+                // Use mousemove + elementsFromPoint to see through FC overlay
+                this._onCalendarDragMove = (ev) => {
+                    if (!this._isDraggingCalendar) return;
+                    const elements = document.elementsFromPoint(ev.clientX, ev.clientY);
+                    for (const el of elements) {
+                        if (el.hasAttribute('data-date')) {
+                            this.dragEndDate = el.getAttribute('data-date');
+                            break;
+                        }
+                    }
+                };
+                document.addEventListener('mousemove', this._onCalendarDragMove);
+                document.addEventListener('mouseup', () => {
+                    this._isDraggingCalendar = false;
+                });
+            }
+            // Create tooltip element (plain DOM, no OWL re-render)
+            this.tooltipEl = document.createElement('div');
+            this.tooltipEl.className = 'rental-event-tooltip';
+            this.tooltipEl.style.display = 'none';
+            document.body.appendChild(this.tooltipEl);
+
+            // Watch for calendar re-renders to apply date range highlighting
+            this.highlightDebounce = null;
+            this.calendarObserver = new MutationObserver(() => {
+                // Debounce to avoid excessive calls during render
+                if (this.highlightDebounce) clearTimeout(this.highlightDebounce);
+                this.highlightDebounce = setTimeout(() => this.applyDateRangeHighlight(), 200);
+            });
+            if (this.calendarRef.el) {
+                this.calendarObserver.observe(this.calendarRef.el, { childList: true, subtree: true });
+            }
+
+            // Watch for Odoo form dialogs opening/closing
+            this.dialogObserver = new MutationObserver((mutations) => {
+                for (const mutation of mutations) {
+                    // Intercept dialog OPENING: redirect to our modal
+                    for (const node of mutation.addedNodes) {
+                        if (node.nodeType === 1) {
+                            const isDialog = node.classList?.contains('o_dialog') ||
+                                node.classList?.contains('modal') ||
+                                node.querySelector?.('.o_form_view') ||
+                                node.querySelector?.('.modal-dialog');
+                            if (isDialog && this.dragStartDate) {
+                                // Close the Odoo dialog
+                                const closeBtn = node.querySelector('.btn-close, .o_form_button_cancel, .close');
+                                if (closeBtn) {
+                                    closeBtn.click();
+                                } else {
+                                    node.remove();
+                                }
+                                // Open our modal with the dragged dates
+                                const startDate = this.dragStartDate;
+                                const endDate = this.dragEndDate || this.dragStartDate;
+                                // Ensure start <= end
+                                const sortedStart = startDate < endDate ? startDate : endDate;
+                                const sortedEnd = startDate < endDate ? endDate : startDate;
+                                this.dragStartDate = null;
+                                this.dragEndDate = null;
+                                this.openCreateModalWithDates(sortedStart, sortedEnd);
+                                return;
+                            }
+                        }
+                    }
+                    // Dialog CLOSING: reload products
+                    for (const node of mutation.removedNodes) {
+                        if (node.nodeType === 1) {
+                            const isDialog = node.classList?.contains('o_dialog') ||
+                                node.classList?.contains('o_technical_modal') ||
+                                node.classList?.contains('modal') ||
+                                node.classList?.contains('o_FormViewDialog') ||
+                                node.querySelector?.('.o_form_view') ||
+                                node.querySelector?.('.modal-dialog');
+                            if (isDialog) {
+                                setTimeout(() => this.loadProducts(), 300);
+                            }
+                        }
+                    }
+                }
+            });
+            this.dialogObserver.observe(document.body, { childList: true, subtree: true });
+
+            this.state.viewLoaded = true;
+        });
+
+        onWillUnmount(() => {
+            if (this.calendarRef.el) {
+                this.calendarRef.el.removeEventListener('click', this.onCalendarClick, true);
+                this.calendarRef.el.removeEventListener('mouseover', this.onEventMouseOver);
+                this.calendarRef.el.removeEventListener('mouseout', this.onEventMouseOut);
+            }
+            if (this.calendarObserver) {
+                this.calendarObserver.disconnect();
+            }
+            if (this.dialogObserver) {
+                this.dialogObserver.disconnect();
+            }
+            if (this.tooltipEl) {
+                this.tooltipEl.remove();
+            }
+            if (this.tooltipTimeout) {
+                clearTimeout(this.tooltipTimeout);
+            }
+        });
+    }
+
+    onCalendarClick(ev) {
+        this.hideTooltip();
+
+        // If clicking "+n more" link, let FC handle it
+        if (ev.target.closest('.fc-more-link, .fc-daygrid-more-link, .fc-more')) {
+            return;
+        }
+
+        // Find if click was on a calendar event
+        const eventEl = ev.target.closest('.fc-event');
+        if (eventEl) {
+            // Stop the event from reaching the calendar's handler
+            ev.stopPropagation();
+            ev.preventDefault();
+
+            // Try multiple ways to get the record ID
+            let recordId = null;
+
+            // Method 1: Check data attribute
+            recordId = eventEl.dataset.eventId || eventEl.getAttribute('data-event-id');
+
+            // Method 2: Try FullCalendar's internal data structure
+            if (!recordId && eventEl.fcSeg) {
+                const fcEvent = eventEl.fcSeg.eventRange?.def;
+                recordId = fcEvent?.publicId || fcEvent?.extendedProps?.recordId;
+            }
+
+            // Method 3: Look for fc-event link with href containing the ID
+            if (!recordId) {
+                const link = eventEl.querySelector('a[href*="id="]');
+                if (link) {
+                    const match = link.href.match(/id=(\d+)/);
+                    if (match) recordId = match[1];
+                }
+            }
+
+            // Method 4: Check the event's title element for data
+            if (!recordId) {
+                const eventData = eventEl.__data__ || eventEl._fc_event;
+                if (eventData) {
+                    recordId = eventData.id || eventData.publicId;
+                }
+            }
+
+            if (recordId) {
+                this.openEditModal(parseInt(recordId));
+            }
+        }
+    }
+
+    onEventMouseOver(ev) {
+        const eventEl = ev.target.closest('.fc-event');
+        if (!eventEl) return;
+
+        if (this.state.showModal) return;
+
+        let recordId = eventEl.dataset.eventId || eventEl.getAttribute('data-event-id');
+        if (!recordId && eventEl.fcSeg) {
+            const fcEvent = eventEl.fcSeg.eventRange?.def;
+            recordId = fcEvent?.publicId || fcEvent?.extendedProps?.recordId;
+        }
+
+        if (!recordId) return;
+
+        // Already showing for this event
+        if (this.currentHoveredEventId === recordId && this.tooltipEl.style.display !== 'none') {
+            return;
+        }
+
+        if (this.tooltipTimeout) {
+            clearTimeout(this.tooltipTimeout);
+            this.tooltipTimeout = null;
+        }
+
+        this.currentHoveredEventId = recordId;
+
+        this.orm.searchRead(
+            "sale.order.line",
+            [["id", "=", parseInt(recordId)]],
+            ["id", "product_id", "start_datetime", "end_datetime", "order_partner_id", "order_id", "rental_qty", "state"]
+        ).then(([soLine]) => {
+            if (this.currentHoveredEventId !== recordId) return;
+            if (this.state.showModal) return;
+
+            if (soLine) {
+                const rect = eventEl.getBoundingClientRect();
+                const productName = soLine.product_id ? soLine.product_id[1] : 'No product';
+                const startDate = this.formatTooltipDate(soLine.start_datetime);
+                const endDate = this.formatTooltipDate(soLine.end_datetime);
+                const customer = soLine.order_partner_id ? soLine.order_partner_id[1] : 'No customer';
+                const orderName = soLine.order_id ? soLine.order_id[1] : '';
+
+                this.tooltipEl.innerHTML = `
+                    <div class="tooltip-content">
+                        <div class="tooltip-title fw-bold mb-2">${_.escape(productName)}</div>
+                        <div class="tooltip-dates mb-2">${_.escape(startDate)} - ${_.escape(endDate)}</div>
+                        <div class="tooltip-info">
+                            <div class="d-flex align-items-center mb-1">
+                                <i class="fa fa-file-text-o me-2 text-muted"></i>
+                                <span>${_.escape(orderName)}</span>
+                            </div>
+                            <div class="d-flex align-items-center mb-1">
+                                <i class="fa fa-user me-2 text-muted"></i>
+                                <span>${_.escape(customer)}</span>
+                            </div>
+                            <div class="d-flex align-items-center">
+                                <i class="fa fa-cubes me-2 text-muted"></i>
+                                <span>Qty: ${soLine.rental_qty}</span>
+                            </div>
+                        </div>
+                    </div>`;
+                this.tooltipEl.style.left = (rect.left + rect.width / 2) + 'px';
+                this.tooltipEl.style.top = (rect.top - 10) + 'px';
+                this.tooltipEl.style.display = '';
+            }
+        });
+    }
+
+    onEventMouseOut(ev) {
+        const eventEl = ev.target.closest('.fc-event');
+        if (!eventEl) return;
+
+        const relatedTarget = ev.relatedTarget;
+        if (relatedTarget && eventEl.contains(relatedTarget)) {
+            return;
+        }
+
+        this.tooltipTimeout = setTimeout(() => {
+            if (this.tooltipEl) this.tooltipEl.style.display = 'none';
+            this.currentHoveredEventId = null;
+        }, 100);
+    }
+
+    hideTooltip() {
+        if (this.tooltipTimeout) {
+            clearTimeout(this.tooltipTimeout);
+        }
+        if (this.tooltipEl) this.tooltipEl.style.display = 'none';
+        this.currentHoveredEventId = null;
+    }
+
+    formatTooltipDate(dateStr) {
+        if (!dateStr) return '';
+        const date = new Date(dateStr);
+        const month = date.getMonth() + 1;
+        const day = date.getDate();
+        const year = String(date.getFullYear()).slice(-2);
+        return `${month}/${day}/${year}`;
+    }
+
+    async loadRentalPeriods() {
+        this.state.rentalPeriods = await this.orm.searchRead(
+            "rental.period",
+            [["active", "=", true]],
+            ["id", "name", "code", "hours_per_unit"],
+            {order: "sequence, id"}
+        );
+    }
+
+    async loadLocations() {
+        // Load only rental_in locations from rental-enabled warehouses
+        const warehouses = await this.orm.searchRead(
+            "stock.warehouse",
+            [["rental_allowed", "=", true]],
+            ["id", "name", "rental_in_location_id", "rental_out_location_id"]
+        );
+        this.state.warehouses = warehouses;
+        this.state.locations = warehouses.map(wh => ({
+            id: wh.rental_in_location_id[0],
+            name: wh.rental_in_location_id[1],
+            display_name: wh.name,
+            rental_out_location_id: wh.rental_out_location_id[0],
+            warehouse_id: wh.id,
+        }));
+    }
+
+    async loadProducts() {
+        // Physical products that have a rental service linked
+        const domain = [["rental_service_ids", "!=", false]];
+
+        // Collect rental_in and rental_out location IDs
+        let rentalInIds = [];
+        let rentalOutIds = [];
+
+        if (this.state.selectedLocation) {
+            // Single selected rental_in location
+            rentalInIds = [this.state.selectedLocation];
+            const loc = this.state.locations.find(l => l.id === this.state.selectedLocation);
+            rentalOutIds = loc ? [loc.rental_out_location_id] : [];
+        } else {
+            // All rental locations
+            rentalInIds = this.state.locations.map(l => l.id);
+            rentalOutIds = this.state.locations.map(l => l.rental_out_location_id);
+        }
+
+        const allLocationIds = [...rentalInIds, ...rentalOutIds];
+
+        // Get stock at rental locations
+        const quants = await this.orm.searchRead(
+            "stock.quant",
+            [
+                ["location_id", "in", allLocationIds],
+                ["quantity", ">", 0],
+            ],
+            ["product_id", "quantity", "location_id"]
+        );
+        // Build maps: rental_in qty (available) and total qty (rental_in + rental_out)
+        const rentalInQtyMap = {};
+        const totalQtyMap = {};
+        quants.forEach(q => {
+            const pid = q.product_id[0];
+            const qty = q.quantity;
+            totalQtyMap[pid] = (totalQtyMap[pid] || 0) + qty;
+            if (rentalInIds.includes(q.location_id[0])) {
+                rentalInQtyMap[pid] = (rentalInQtyMap[pid] || 0) + qty;
+            }
+        });
+
+
+        // Get committed rental qty from active sale.rental records
+        // "ordered" = confirmed but not yet picked from rental_in
+        // Filter by out_picking_id.location_id to match selected location(s)
+        // Filter by date range overlap if dates are selected
+        const rentalDomain = [["state", "=", "ordered"]];
+        if (rentalInIds.length > 0) {
+            rentalDomain.push(["out_picking_id.location_id", "in", rentalInIds]);
+        }
+        if (this.state.dateFrom) {
+            rentalDomain.push(["start_datetime", "<=", this.state.dateTo || this.state.dateFrom]);
+        }
+        if (this.state.dateTo) {
+            rentalDomain.push(["end_datetime", ">=", this.state.dateFrom || this.state.dateTo]);
+        }
+        const rentals = await this.orm.searchRead(
+            "sale.rental",
+            rentalDomain,
+            ["rented_product_id", "rental_qty"]
+        );
+        const committedQtyMap = {};
+        rentals.forEach(r => {
+            const pid = r.rented_product_id[0];
+            committedQtyMap[pid] = (committedQtyMap[pid] || 0) + r.rental_qty;
+        });
+
+        // If location selected, filter to products with stock at those locations
+        const productIdsAtLocation = Object.keys(totalQtyMap).map(Number);
+        if (this.state.selectedLocation) {
+            if (productIdsAtLocation.length > 0) {
+                domain.push(["id", "in", productIdsAtLocation]);
+            } else {
+                this.state.products = [];
+                return;
+            }
+        }
+
+        const products = await this.orm.searchRead(
+            "product.product",
+            domain,
+            ["id", "name", "default_code", "rental_color"]
+        );
+
+        // qty_total = rental_in + rental_out (total fleet)
+        // qty_available = rental_in - committed rental qty (truly available)
+        products.forEach(p => {
+            p.qty_total = totalQtyMap[p.id] || 0;
+            const rentalInQty = rentalInQtyMap[p.id] || 0;
+            const committed = committedQtyMap[p.id] || 0;
+            p.qty_available = Math.max(0, rentalInQty - committed);
+
+            if (p.qty_available > 5) {
+                p.availability_status = 'available';
+            } else if (p.qty_available > 0) {
+                p.availability_status = 'low';
+            } else {
+                p.availability_status = 'unavailable';
+            }
+        });
+        this.state.products = products;
+    }
+
+    async loadModalProducts() {
+        const locationId = this.state.modalData.locationId;
+
+        // Determine rental_in location(s)
+        let rentalInIds = [];
+        if (locationId) {
+            rentalInIds = [locationId];
+        } else {
+            rentalInIds = this.state.locations.map(l => l.id);
+        }
+
+        // Get stock at rental_in location(s) for physical products
+        const quants = await this.orm.searchRead(
+            "stock.quant",
+            [
+                ["location_id", "in", rentalInIds],
+                ["quantity", ">", 0],
+            ],
+            ["product_id", "quantity"]
+        );
+        const rentalInQtyMap = {};
+        quants.forEach(q => {
+            const pid = q.product_id[0];
+            rentalInQtyMap[pid] = (rentalInQtyMap[pid] || 0) + q.quantity;
+        });
+
+        // Get committed rental qty filtered by location
+        const rentalDomain = [["state", "=", "ordered"]];
+        if (rentalInIds.length > 0) {
+            rentalDomain.push(["out_picking_id.location_id", "in", rentalInIds]);
+        }
+        const rentals = await this.orm.searchRead(
+            "sale.rental",
+            rentalDomain,
+            ["rented_product_id", "rental_qty"]
+        );
+        const committedQtyMap = {};
+        rentals.forEach(r => {
+            const pid = r.rented_product_id[0];
+            committedQtyMap[pid] = (committedQtyMap[pid] || 0) + r.rental_qty;
+        });
+
+        // Load physical products to get their rental_service_ids
+        const physicalDomain = [["rental_service_ids", "!=", false]];
+        if (locationId) {
+            const productIdsAtLocation = Object.keys(rentalInQtyMap).map(Number);
+            if (productIdsAtLocation.length > 0) {
+                physicalDomain.push(["id", "in", productIdsAtLocation]);
+            } else {
+                this.state.modalProducts = [];
+                return;
+            }
+        }
+
+        const physicalProducts = await this.orm.searchRead(
+            "product.product",
+            physicalDomain,
+            ["id", "name", "rental_service_ids"]
+        );
+
+        // Build availability map for physical products
+        const availMap = {};
+        physicalProducts.forEach(p => {
+            const rentalInQty = rentalInQtyMap[p.id] || 0;
+            const committed = committedQtyMap[p.id] || 0;
+            availMap[p.id] = Math.max(0, rentalInQty - committed);
+        });
+
+        // Collect all rental service IDs
+        const allServiceIds = [];
+        physicalProducts.forEach(p => {
+            allServiceIds.push(...p.rental_service_ids);
+        });
+
+        if (allServiceIds.length === 0) {
+            this.state.modalProducts = [];
+            return;
+        }
+
+        // Load service products
+        const serviceProducts = await this.orm.searchRead(
+            "product.product",
+            [["id", "in", allServiceIds]],
+            ["id", "name", "rented_product_id"]
+        );
+
+        // Attach physical product availability to each service product
+        serviceProducts.forEach(sp => {
+            const physicalId = sp.rented_product_id ? sp.rented_product_id[0] : null;
+            sp.physicalProductId = physicalId;
+            sp.qty_available = physicalId ? (availMap[physicalId] || 0) : 0;
+        });
+
+        this.state.modalProducts = serviceProducts;
+    }
+
+    get filteredProducts() {
+        let products = this.state.products;
+
+        if (this.state.showAvailableOnly) {
+            products = products.filter(p => p.qty_available > 0);
+        }
+
+        return products;
+    }
+
+    get calendarDomain() {
+        // Only rental SO lines, exclude cancelled orders
+        const domain = [
+            ["rental", "=", true],
+            ["state", "not in", ["cancel"]],
+        ];
+
+        // Filter by warehouse matching the selected rental_in location
+        if (this.state.selectedLocation) {
+            const loc = this.state.locations.find(l => l.id === this.state.selectedLocation);
+            if (loc) {
+                domain.push(["order_id.warehouse_id", "=", loc.warehouse_id]);
+            }
+        }
+
+        // Filter by date range (overlapping)
+        if (this.state.dateFrom) {
+            domain.push(["end_datetime", ">=", this.state.dateFrom]);
+        }
+        if (this.state.dateTo) {
+            domain.push(["start_datetime", "<=", this.state.dateTo]);
+        }
+
+        // Filter by selected products (physical) via rental_service_ids
+        if (this.state.selectedProducts.length > 0) {
+            domain.push(["product_id.rented_product_id", "in", this.state.selectedProducts]);
+        }
+
+        return domain;
+    }
+
+    get calendarProps() {
+        if (!this.state.viewLoaded) return null;
+
+        return {
+            resModel: "sale.order.line",
+            type: "calendar",
+            domain: this.calendarDomain,
+            context: this.props.context || {},
+            display: {
+                // controlPanel: false,
+            },
+        };
+    }
+
+
+    // Actions
+    async onLocationChange(ev) {
+        const value = ev.target.value;
+        this.state.selectedLocation = value ? parseInt(value) : null;
+        this.state.selectedProducts = []; // Clear product selection when location changes
+        await this.loadProducts(); // Reload products for new location
+        this.state.calendarKey++; // Force calendar re-render
+    }
+
+    onShowAvailableChange(ev) {
+        this.state.showAvailableOnly = ev.target.checked;
+    }
+
+    onProductSelect(productId) {
+        const index = this.state.selectedProducts.indexOf(productId);
+        if (index > -1) {
+            this.state.selectedProducts.splice(index, 1);
+        } else {
+            this.state.selectedProducts.push(productId);
+        }
+        this.state.calendarKey++; // Force calendar re-render
+    }
+
+    isProductSelected(productId) {
+        return this.state.selectedProducts.includes(productId);
+    }
+
+    async clearFilters() {
+        this.state.selectedLocation = null;
+        this.state.dateFrom = null;
+        this.state.dateTo = null;
+        this.state.showDatePicker = false;
+        this.state.showAvailableOnly = false;
+        this.state.selectedProducts = [];
+        await this.loadProducts(); // Reload all products
+        this.state.calendarKey++;
+    }
+
+    // Date filter functions
+    toggleDatePicker() {
+        this.state.showDatePicker = !this.state.showDatePicker;
+    }
+
+    onDateFromChange(ev) {
+        this.state.dateFrom = ev.target.value || null;
+    }
+
+    onDateToChange(ev) {
+        this.state.dateTo = ev.target.value || null;
+    }
+
+    async applyDateFilter() {
+        this.state.showDatePicker = false;
+        this.state.calendarKey++;
+        await this.loadProducts(); // Recalculate availability based on date range
+        // Delay to let calendar re-render, then highlight
+        setTimeout(() => this.applyDateRangeHighlight(), 500);
+    }
+
+    async clearDateFilter() {
+        this.state.dateFrom = null;
+        this.state.dateTo = null;
+        this.state.showDatePicker = false;
+        this.state.calendarKey++;
+        await this.loadProducts(); // Recalculate availability
+        this.applyDateRangeHighlight();
+    }
+
+    applyDateRangeHighlight() {
+        if (!this.calendarRef.el) return;
+
+        // Try multiple selectors for different FullCalendar versions
+        let dayCells = this.calendarRef.el.querySelectorAll('.fc-daygrid-day[data-date]');
+        if (!dayCells.length) {
+            dayCells = this.calendarRef.el.querySelectorAll('td[data-date]');
+        }
+        if (!dayCells.length) {
+            dayCells = this.calendarRef.el.querySelectorAll('.fc-day[data-date]');
+        }
+        if (!dayCells.length) return;
+
+        // Remove existing classes first
+        dayCells.forEach(cell => {
+            cell.classList.remove('date-in-range', 'date-outside-range');
+        });
+
+        // If no date range selected, don't highlight anything
+        if (!this.state.dateFrom || !this.state.dateTo) return;
+
+        const fromDate = new Date(this.state.dateFrom + 'T00:00:00');
+        const toDate = new Date(this.state.dateTo + 'T23:59:59');
+
+        dayCells.forEach(cell => {
+            const dateAttr = cell.getAttribute('data-date');
+            if (!dateAttr) return;
+
+            const cellDate = new Date(dateAttr + 'T12:00:00');
+
+            if (cellDate >= fromDate && cellDate <= toDate) {
+                cell.classList.add('date-in-range');
+            } else {
+                cell.classList.add('date-outside-range');
+            }
+        });
+    }
+
+    formatDateRange() {
+        if (!this.state.dateFrom || !this.state.dateTo) return '';
+
+        const from = new Date(this.state.dateFrom);
+        const to = new Date(this.state.dateTo);
+
+        // Calculate days difference
+        const diffTime = Math.abs(to - from);
+        const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24)) + 1;
+
+        // Format dates as M/D/YY
+        const formatDate = (date) => {
+            const month = date.getMonth() + 1;
+            const day = date.getDate();
+            const year = String(date.getFullYear()).slice(-2);
+            return `${month}/${day}/${year}`;
+        };
+
+        return `${formatDate(from)} - ${formatDate(to)} (${diffDays} days)`;
+    }
+
+    // Modal functions
+    async openCreateModal() {
+        this.state.modalMode = 'create';
+        this.state.editingOrderId = null;
+        this.state.modalData = {
+            locationId: this.state.selectedLocation,
+            customerId: null,
+            customerSearch: '',
+            startDate: this.state.dateFrom || this.formatDateForInput(new Date()),
+            endDate: this.state.dateTo || this.formatDateForInput(new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)),
+            state: null,
+            lines: [],
+        };
+
+        await this.loadModalProducts();
+
+        // Initialize lines from pre-selected physical products (sidebar)
+        // Map physical product IDs to their service products
+        const lines = [];
+        if (this.state.selectedProducts.length > 0) {
+            for (const physicalId of this.state.selectedProducts) {
+                // Find the first service product for this physical product
+                const service = this.state.modalProducts.find(p => p.physicalProductId === physicalId);
+                if (service) {
+                    // Load available periods from product.rental.pricing
+                    const pricings = await this.orm.searchRead(
+                        "product.rental.pricing",
+                        [["product_id", "=", service.id]],
+                        ["period_id"]
+                    );
+                    const availablePeriodIds = pricings.map(p => p.period_id[0]);
+                    const rentalPeriodId = availablePeriodIds.length > 0 ? availablePeriodIds[0] : null;
+                    const priceUnit = rentalPeriodId ? await this.computePriceUnit(service.id, rentalPeriodId) : 0;
+
+                    lines.push({
+                        id: Date.now() + Math.random(),
+                        productId: service.id,
+                        rentalType: 'new_rental',
+                        rentalPeriodId: rentalPeriodId,
+                        availablePeriodIds: availablePeriodIds,
+                        rentalQty: 1,
+                        priceUnit: priceUnit,
+                        available: service.qty_available || 0,
+                    });
+                }
+            }
+        }
+
+        this.state.modalData.lines = lines.length > 0 ? lines : [this.createEmptyLine()];
+
+        this.hideTooltip();
+        this.state.showModal = true;
+    }
+
+    async openCreateModalWithDates(startDate, endDate) {
+        this.state.modalMode = 'create';
+        this.state.editingOrderId = null;
+        this.state.modalData = {
+            locationId: this.state.selectedLocation,
+            customerId: null,
+            customerSearch: '',
+            startDate: startDate,
+            endDate: endDate,
+            state: null,
+            lines: [],
+        };
+
+        await this.loadModalProducts();
+        this.state.modalData.lines = [this.createEmptyLine()];
+
+        this.hideTooltip();
+        this.state.showModal = true;
+    }
+
+    async openEditModal(soLineId) {
+        try {
+            // Load the SO line to get order_id
+            const [soLine] = await this.orm.searchRead(
+                "sale.order.line",
+                [["id", "=", soLineId]],
+                ["order_id"]
+            );
+            if (!soLine) {
+                console.error("SO line not found:", soLineId);
+                return;
+            }
+
+            const orderId = soLine.order_id[0];
+
+            // Load the sale order
+            const [order] = await this.orm.searchRead(
+                "sale.order",
+                [["id", "=", orderId]],
+                ["id", "partner_id", "warehouse_id", "state"]
+            );
+            if (!order) {
+                console.error("Sale order not found:", orderId);
+                return;
+            }
+
+            // Find location from warehouse
+            const loc = this.state.locations.find(l => l.warehouse_id === order.warehouse_id[0]);
+
+            // Load all rental SO lines for this order
+            const orderLines = await this.orm.searchRead(
+                "sale.order.line",
+                [["order_id", "=", orderId], ["rental", "=", true]],
+                ["id", "product_id", "rental_type", "rental_period_id", "rental_qty",
+                 "price_unit", "start_datetime", "end_datetime"]
+            );
+
+            // Use dates from first line
+            const firstLine = orderLines[0];
+            const startDt = firstLine ? firstLine.start_datetime : null;
+            const endDt = firstLine ? firstLine.end_datetime : null;
+
+            // Set up modal data (need locationId for loadModalProducts)
+            this.state.modalMode = 'edit';
+            this.state.editingOrderId = orderId;
+            this.state.modalData = {
+                locationId: loc ? loc.id : null,
+                customerId: order.partner_id[0],
+                customerSearch: order.partner_id[1],
+                startDate: startDt ? startDt.split(' ')[0] : null,
+                endDate: endDt ? endDt.split(' ')[0] : null,
+                state: order.state,
+                lines: [],
+            };
+
+            await this.loadModalProducts();
+
+            // Map SO lines: product_id is the service product directly
+            const lines = [];
+            for (const line of orderLines) {
+                const serviceProductId = line.product_id[0];
+                const modalProduct = this.state.modalProducts.find(p => p.id === serviceProductId);
+
+                // Load available periods from product.rental.pricing
+                const pricings = await this.orm.searchRead(
+                    "product.rental.pricing",
+                    [["product_id", "=", serviceProductId]],
+                    ["period_id"]
+                );
+
+                lines.push({
+                    id: line.id,
+                    productId: serviceProductId,
+                    rentalType: line.rental_type,
+                    rentalPeriodId: line.rental_period_id ? line.rental_period_id[0] : null,
+                    availablePeriodIds: pricings.map(p => p.period_id[0]),
+                    rentalQty: line.rental_qty,
+                    priceUnit: line.price_unit,
+                    available: modalProduct ? modalProduct.qty_available : 0,
+                });
+            }
+
+            this.state.modalData.lines = lines.length > 0 ? lines : [this.createEmptyLine()];
+
+            this.hideTooltip();
+            this.state.showModal = true;
+
+        } catch (error) {
+            console.error("Error loading sale order:", error);
+            alert("Error loading rental data. Please try again.");
+        }
+    }
+
+    createEmptyLine() {
+        return {
+            id: Date.now() + Math.random(),
+            productId: null,       // service product ID (sale.order.line.product_id)
+            rentalType: 'new_rental',
+            rentalPeriodId: null,
+            availablePeriodIds: [],
+            rentalQty: 1,
+            priceUnit: 0,
+            available: 0,
+        };
+    }
+
+    closeModal() {
+        this.state.showModal = false;
+        this.state.createdOrderId = null;
+    }
+
+    openEditingOrder() {
+        if (!this.state.editingOrderId) return;
+        this.action.doAction({
+            type: "ir.actions.act_window",
+            res_model: "sale.order",
+            res_id: this.state.editingOrderId,
+            views: [[false, "form"]],
+            target: "current",
+        });
+    }
+
+    async confirmEditingOrder() {
+        if (!this.state.editingOrderId) return;
+        try {
+            await this.orm.call("sale.order", "action_confirm", [this.state.editingOrderId]);
+            this.state.modalData.state = 'sale';
+            this.state.calendarKey++;
+            await this.loadProducts();
+        } catch (error) {
+            console.error("Error confirming order:", error);
+            alert("Error confirming order. Please try again.");
+        }
+    }
+
+    openCreatedOrder() {
+        if (!this.state.createdOrderId) return;
+        this.action.doAction({
+            type: "ir.actions.act_window",
+            res_model: "sale.order",
+            res_id: this.state.createdOrderId,
+            views: [[false, "form"]],
+            target: "current",
+        });
+    }
+
+    async confirmCreatedOrder() {
+        if (!this.state.createdOrderId) return;
+        try {
+            await this.orm.call("sale.order", "action_confirm", [this.state.createdOrderId]);
+            this.state.showModal = false;
+            this.state.createdOrderId = null;
+            this.state.calendarKey++;
+            await this.loadProducts();
+        } catch (error) {
+            console.error("Error confirming order:", error);
+            alert("Error confirming order. Please try again.");
+        }
+    }
+
+    formatDateForInput(date) {
+        return date.toISOString().split('T')[0];
+    }
+
+    async onModalLocationChange(ev) {
+        this.state.modalData.locationId = ev.target.value ? parseInt(ev.target.value) : null;
+        // Reload products for the new location
+        await this.loadModalProducts();
+    }
+
+    async onCustomerSearch(ev) {
+        const search = ev.target.value;
+        this.state.modalData.customerSearch = search;
+
+        if (search.length >= 2) {
+            this.state.customers = await this.orm.searchRead(
+                "res.partner",
+                ["|", ["name", "ilike", search], ["email", "ilike", search]],
+                ["id", "name", "email"],
+                {limit: 10}
+            );
+        } else {
+            this.state.customers = [];
+        }
+    }
+
+    selectCustomer(customer) {
+        this.state.modalData.customerId = customer.id;
+        this.state.modalData.customerSearch = customer.name;
+        this.state.customers = [];
+    }
+
+    onModalStartDateChange(ev) {
+        this.state.modalData.startDate = ev.target.value;
+    }
+
+    onModalEndDateChange(ev) {
+        this.state.modalData.endDate = ev.target.value;
+    }
+
+    async onLineProductChange(line, ev) {
+        const productId = ev.target.value ? parseInt(ev.target.value) : null;
+        line.productId = productId;
+        line.availablePeriodIds = [];
+        line.rentalPeriodId = null;
+        line.priceUnit = 0;
+
+        if (productId) {
+            const product = this.state.modalProducts.find(p => p.id === productId);
+            if (product) {
+                line.available = product.qty_available || 0;
+
+                // Load available periods from product.rental.pricing
+                const pricings = await this.orm.searchRead(
+                    "product.rental.pricing",
+                    [["product_id", "=", productId]],
+                    ["period_id"]
+                );
+                line.availablePeriodIds = pricings.map(p => p.period_id[0]);
+
+                // Auto-select first available period
+                if (line.availablePeriodIds.length > 0) {
+                    line.rentalPeriodId = line.availablePeriodIds[0];
+                    line.priceUnit = await this.computePriceUnit(productId, line.rentalPeriodId);
+                }
+            }
+        }
+    }
+
+    getLineAvailablePeriods(line) {
+        if (!line.availablePeriodIds || line.availablePeriodIds.length === 0) {
+            return [];
+        }
+        return this.state.rentalPeriods.filter(p => line.availablePeriodIds.includes(p.id));
+    }
+
+    onLineRentalTypeChange(line, ev) {
+        line.rentalType = ev.target.value || 'new_rental';
+    }
+
+    async onLineRentalPeriodChange(line, ev) {
+        line.rentalPeriodId = ev.target.value ? parseInt(ev.target.value) : null;
+        if (line.productId && line.rentalPeriodId) {
+            line.priceUnit = await this.computePriceUnit(line.productId, line.rentalPeriodId);
+        }
+    }
+
+    onLineRentalQtyChange(line, ev) {
+        line.rentalQty = parseFloat(ev.target.value) || 1;
+    }
+
+    onLinePriceUnitChange(line, ev) {
+        line.priceUnit = parseFloat(ev.target.value) || 0;
+    }
+
+    async computePriceUnit(serviceProductId, periodId) {
+        if (!serviceProductId || !periodId) return 0;
+
+        // Get base price per period from product.rental.pricing
+        const [pricing] = await this.orm.searchRead(
+            "product.rental.pricing",
+            [["product_id", "=", serviceProductId], ["period_id", "=", periodId]],
+            ["price"]
+        );
+        if (!pricing) return 0;
+
+        const basePrice = pricing.price;
+        const period = this.state.rentalPeriods.find(p => p.id === periodId);
+        if (!period) return basePrice;
+
+        // Match sale_rental _compute_price_unit:
+        // duration = diff_hours / hours_per_unit
+        // number_of_days = diff_hours / 24
+        // price_unit = (base_price * duration) / number_of_days
+        const diffHours = this.getDiffHours();
+        if (diffHours <= 0) return basePrice;
+
+        const duration = diffHours / period.hours_per_unit;
+        const numberOfDays = diffHours / 24;
+        return (basePrice * duration) / numberOfDays;
+    }
+
+    getDiffHours() {
+        if (!this.state.modalData.startDate || !this.state.modalData.endDate) return 0;
+        const from = new Date(this.state.modalData.startDate + 'T00:00:00');
+        const to = new Date(this.state.modalData.endDate + 'T00:00:00');
+        return Math.max(0, (to - from) / (1000 * 60 * 60));
+    }
+
+    getNumberOfDays() {
+        const diffHours = this.getDiffHours();
+        return diffHours > 0 ? diffHours / 24 : 1;
+    }
+
+    getLineSubtotal(line) {
+        // Match sale_rental: price_subtotal = price_unit * product_uom_qty
+        // where product_uom_qty = rental_qty * number_of_days
+        return line.priceUnit * line.rentalQty * this.getNumberOfDays();
+    }
+
+    getLineTotal(line) {
+        return this.getLineSubtotal(line);
+    }
+
+    get modalSubtotal() {
+        return this.state.modalData.lines.reduce((sum, line) => sum + this.getLineSubtotal(line), 0);
+    }
+
+    get modalTotal() {
+        return this.modalSubtotal;
+    }
+
+    addLine() {
+        this.state.modalData.lines.push(this.createEmptyLine());
+    }
+
+    removeLine(lineId) {
+        const index = this.state.modalData.lines.findIndex(l => l.id === lineId);
+        if (index > -1 && this.state.modalData.lines.length > 1) {
+            this.state.modalData.lines.splice(index, 1);
+        }
+    }
+
+    formatCurrency(amount) {
+        return '$' + amount.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    }
+
+    async checkAvailability(validLines, locationId, startDate, endDate) {
+        const rentalInIds = [locationId];
+
+        // Get stock at rental_in location
+        const quants = await this.orm.searchRead(
+            "stock.quant",
+            [["location_id", "in", rentalInIds], ["quantity", ">", 0]],
+            ["product_id", "quantity"]
+        );
+        const rentalInQtyMap = {};
+        quants.forEach(q => {
+            const pid = q.product_id[0];
+            rentalInQtyMap[pid] = (rentalInQtyMap[pid] || 0) + q.quantity;
+        });
+
+        // Get committed rentals overlapping with the date range
+        const rentalDomain = [
+            ["state", "=", "ordered"],
+            ["out_picking_id.location_id", "in", rentalInIds],
+            ["start_datetime", "<=", endDate + " 00:00:00"],
+            ["end_datetime", ">=", startDate + " 00:00:00"],
+        ];
+        // Exclude current order when editing
+        if (this.state.modalMode === 'edit' && this.state.editingOrderId) {
+            rentalDomain.push(["start_order_id", "!=", this.state.editingOrderId]);
+        }
+        const rentals = await this.orm.searchRead(
+            "sale.rental",
+            rentalDomain,
+            ["rented_product_id", "rental_qty"]
+        );
+        const committedQtyMap = {};
+        rentals.forEach(r => {
+            const pid = r.rented_product_id[0];
+            committedQtyMap[pid] = (committedQtyMap[pid] || 0) + r.rental_qty;
+        });
+
+        // Check each line: find physical product via modalProducts, then check availability
+        // Also aggregate qty per physical product across lines
+        const requestedQtyMap = {};
+        for (const line of validLines) {
+            const modalProduct = this.state.modalProducts.find(p => p.id === line.productId);
+            const physicalId = modalProduct ? modalProduct.physicalProductId : null;
+            if (physicalId) {
+                requestedQtyMap[physicalId] = (requestedQtyMap[physicalId] || 0) + line.rentalQty;
+            }
+        }
+
+        const errors = [];
+        for (const [physicalId, requestedQty] of Object.entries(requestedQtyMap)) {
+            const rentalInQty = rentalInQtyMap[physicalId] || 0;
+            const committed = committedQtyMap[physicalId] || 0;
+            const available = Math.max(0, rentalInQty - committed);
+            if (requestedQty > available) {
+                // Find product name from modal products
+                const product = this.state.modalProducts.find(p => p.physicalProductId === parseInt(physicalId));
+                const name = product ? product.name : 'Unknown';
+                errors.push(`${name}: requested ${requestedQty}, available ${available}`);
+            }
+        }
+
+        return errors;
+    }
+
+    async confirmRental() {
+        const data = this.state.modalData;
+
+        // Validation
+        if (!data.locationId) {
+            alert('Please select a location');
+            return;
+        }
+        if (!data.customerId) {
+            alert('Please select a customer');
+            return;
+        }
+        if (!data.startDate || !data.endDate) {
+            alert('Please select start and end dates');
+            return;
+        }
+
+        const validLines = data.lines.filter(l => l.productId && l.rentalQty > 0);
+        if (validLines.length === 0) {
+            alert('Please add at least one equipment with a rental service configured');
+            return;
+        }
+
+        // Get warehouse from selected location
+        const loc = this.state.locations.find(l => l.id === data.locationId);
+        if (!loc) {
+            alert('Invalid location');
+            return;
+        }
+
+        // Check availability before saving
+        const availErrors = await this.checkAvailability(validLines, data.locationId, data.startDate, data.endDate);
+        if (availErrors.length > 0) {
+            alert('Insufficient availability:\n\n' + availErrors.join('\n'));
+            return;
+        }
+
+        const startDatetime = data.startDate + ' 00:00:00';
+        const endDatetime = data.endDate + ' 00:00:00';
+        const diffHours = this.getDiffHours();
+        const numberOfDays = diffHours / 24;
+
+        try {
+            if (this.state.modalMode === 'edit' && this.state.editingOrderId) {
+                // Update existing SO (only if draft)
+                await this.orm.write("sale.order", [this.state.editingOrderId], {
+                    partner_id: data.customerId,
+                    warehouse_id: loc.warehouse_id,
+                });
+
+                // Delete old rental lines and create new ones
+                const oldLines = await this.orm.searchRead(
+                    "sale.order.line",
+                    [["order_id", "=", this.state.editingOrderId], ["rental", "=", true]],
+                    ["id"]
+                );
+                if (oldLines.length > 0) {
+                    await this.orm.unlink("sale.order.line", oldLines.map(l => l.id));
+                }
+
+                for (const line of validLines) {
+                    await this.orm.create("sale.order.line", [{
+                        order_id: this.state.editingOrderId,
+                        product_id: line.productId,
+                        rental: true,
+                        rental_type: line.rentalType,
+                        rental_qty: line.rentalQty,
+                        rental_period_id: line.rentalPeriodId,
+                        start_datetime: startDatetime,
+                        end_datetime: endDatetime,
+                        product_uom_qty: line.rentalQty * numberOfDays,
+                        price_unit: line.priceUnit,
+                    }]);
+                }
+
+            } else {
+                // Create new sale order
+                const orderId = await this.orm.create("sale.order", [{
+                    partner_id: data.customerId,
+                    warehouse_id: loc.warehouse_id,
+                }]);
+                this.state.createdOrderId = orderId;
+
+                // Create SO lines
+                for (const line of validLines) {
+                    await this.orm.create("sale.order.line", [{
+                        order_id: orderId,
+                        product_id: line.productId,
+                        rental: true,
+                        rental_type: line.rentalType,
+                        rental_qty: line.rentalQty,
+                        rental_period_id: line.rentalPeriodId,
+                        start_datetime: startDatetime,
+                        end_datetime: endDatetime,
+                        product_uom_qty: line.rentalQty * numberOfDays,
+                        price_unit: line.priceUnit,
+                    }]);
+                }
+
+            }
+
+            // Refresh calendar and products
+            this.state.calendarKey++;
+            await this.loadProducts();
+
+            if (this.state.modalMode === 'create' && this.state.createdOrderId) {
+                // Show success state with action buttons
+                this.state.modalMode = 'created';
+            } else {
+                this.state.showModal = false;
+            }
+
+        } catch (error) {
+            console.error('Error saving rental:', error);
+            alert('Error saving rental. Please try again.');
+        }
+    }
+
+    getAvailabilityClass(product) {
+        if (product.availability_status === 'available') return 'bg-success';
+        if (product.availability_status === 'low') return 'bg-warning';
+        return 'bg-danger';
+    }
+
+    getAvailabilityText(product) {
+        const available = product.qty_available || 0;
+        const total = product.qty_total;
+        if (total !== undefined && total !== available) {
+            if (available > 0) return `${available} of ${total} available`;
+            return `0 of ${total} available`;
+        }
+        if (available > 0) return `${available} available`;
+        return 'Unavailable';
+    }
+
+    getProductColorStyle(product) {
+        const colors = ['#CCCCCC', '#F06050', '#F4A460', '#F7CD1F', '#6CC1ED', '#814968', '#EB7E7F', '#2C8397', '#475577', '#D6145F', '#30C381', '#9365B8'];
+        const color = colors[product.rental_color || 0];
+        return `background-color: ${color};`;
+    }
+
+    getStatusBadgeClass(state) {
+        const classes = {
+            'draft': 'bg-secondary',
+            'sent': 'bg-info',
+            'sale': 'bg-primary',
+            'done': 'bg-success',
+            'cancel': 'bg-danger',
+        };
+        return classes[state] || 'bg-secondary';
+    }
+
+    getStatusLabel(state) {
+        const labels = {
+            'draft': 'Quotation',
+            'sent': 'Sent',
+            'sale': 'Confirmed',
+            'done': 'Done',
+            'cancel': 'Cancelled',
+        };
+        return labels[state] || state;
+    }
+
+    async openCalendar() {
+        this.action.doAction({
+            type: "ir.actions.act_window",
+            name: "Rental Calendar",
+            res_model: "sale.order.line",
+            views: [[false, "calendar"], [false, "form"]],
+            target: "current",
+            domain: [["rental", "=", true]],
+        });
+    }
+}
+
+RentalDashboard.template = "rental_dashboard.RentalDashboard";
+RentalDashboard.components = {View};
+RentalDashboard.props = {"*": true};
+
+registry.category("actions").add("rental_dashboard.dashboard", RentalDashboard);

--- a/rental_dashboard/static/src/js/rental_dashboard.js
+++ b/rental_dashboard/static/src/js/rental_dashboard.js
@@ -2,7 +2,14 @@
 
 import {registry} from "@web/core/registry";
 import {useService} from "@web/core/utils/hooks";
-import {Component, useState, onWillStart, onMounted, onWillUnmount, useRef} from "@odoo/owl";
+import {
+    Component,
+    useState,
+    onWillStart,
+    onMounted,
+    onWillUnmount,
+    useRef,
+} from "@odoo/owl";
 import {View} from "@web/views/view";
 
 export class RentalDashboard extends Component {
@@ -26,9 +33,9 @@ export class RentalDashboard extends Component {
             locations: [],
             warehouses: [],
             products: [],
-            modalProducts: [], // Products filtered by modal location
+            modalProducts: [],
             customers: [],
-            rentalPeriods: [], // rental.period records
+            rentalPeriods: [],
 
             // Calendar key for re-render
             calendarKey: 0,
@@ -36,22 +43,21 @@ export class RentalDashboard extends Component {
 
             // Modal state
             showModal: false,
-            modalMode: 'create', // 'create', 'edit', or 'created'
+            modalMode: "create",
             editingOrderId: null,
             createdOrderId: null,
             modalData: {
                 locationId: null,
                 customerId: null,
-                customerSearch: '',
+                customerSearch: "",
                 startDate: null,
                 endDate: null,
                 state: null,
                 lines: [],
             },
-
         });
 
-        // Bind event handlers
+        // Bind event handlers once (for proper removeEventListener)
         this.onCalendarClick = this.onCalendarClick.bind(this);
         this.onEventMouseOver = this.onEventMouseOver.bind(this);
         this.onEventMouseOut = this.onEventMouseOut.bind(this);
@@ -60,218 +66,240 @@ export class RentalDashboard extends Component {
         this.tooltipTimeout = null;
         this.currentHoveredEventId = null;
         this.tooltipEl = null;
+        this.tooltipCache = new Map();
 
         // Track calendar cell drag for date range selection
         this.dragStartDate = null;
         this.dragEndDate = null;
+        this._isDraggingCalendar = false;
+
+        // ── Lifecycle ──
 
         onWillStart(async () => {
-            await this.loadLocations();
-            await this.loadRentalPeriods();
-            await this.loadProducts();
+            // Single RPC replaces loadLocations + loadRentalPeriods + loadProducts
+            const data = await this.orm.call(
+                "product.product",
+                "get_rental_dashboard_data",
+                [],
+                {location_id: null, date_from: null, date_to: null}
+            );
+            this.state.locations = data.locations;
+            this.state.warehouses = data.warehouses;
+            this.state.rentalPeriods = data.rental_periods;
+            this.state.products = data.products;
         });
 
         onMounted(() => {
-            if (this.calendarRef.el) {
-                this.calendarRef.el.addEventListener('click', this.onCalendarClick, true);
-                this.calendarRef.el.addEventListener('mouseover', this.onEventMouseOver);
-                this.calendarRef.el.addEventListener('mouseout', this.onEventMouseOut);
-
-                // Track drag selection on calendar cells
-                // Use elementsFromPoint to see through FC event harness overlays
-                this.calendarRef.el.addEventListener('mousedown', (ev) => {
-                    const elements = document.elementsFromPoint(ev.clientX, ev.clientY);
-                    // Skip if clicking directly on a calendar event
-                    if (elements.some(el => el.classList && el.classList.contains('fc-event') ||
-                                            el.closest && el.closest('.fc-event'))) return;
-                    // Find the day cell underneath
-                    let date = null;
-                    for (const el of elements) {
-                        if (el.hasAttribute && el.hasAttribute('data-date')) {
-                            date = el.getAttribute('data-date');
-                            break;
-                        }
-                    }
-                    if (date) {
-                        this.dragStartDate = date;
-                        this.dragEndDate = date;
-                        this._isDraggingCalendar = true;
-                    }
-                });
-                // Use mousemove + elementsFromPoint to see through FC overlay
-                this._onCalendarDragMove = (ev) => {
-                    if (!this._isDraggingCalendar) return;
-                    const elements = document.elementsFromPoint(ev.clientX, ev.clientY);
-                    for (const el of elements) {
-                        if (el.hasAttribute('data-date')) {
-                            this.dragEndDate = el.getAttribute('data-date');
-                            break;
-                        }
-                    }
-                };
-                document.addEventListener('mousemove', this._onCalendarDragMove);
-                document.addEventListener('mouseup', () => {
-                    this._isDraggingCalendar = false;
-                });
-            }
-            // Create tooltip element (plain DOM, no OWL re-render)
-            this.tooltipEl = document.createElement('div');
-            this.tooltipEl.className = 'rental-event-tooltip';
-            this.tooltipEl.style.display = 'none';
-            document.body.appendChild(this.tooltipEl);
-
-            // Watch for calendar re-renders to apply date range highlighting
-            this.highlightDebounce = null;
-            this.calendarObserver = new MutationObserver(() => {
-                // Debounce to avoid excessive calls during render
-                if (this.highlightDebounce) clearTimeout(this.highlightDebounce);
-                this.highlightDebounce = setTimeout(() => this.applyDateRangeHighlight(), 200);
-            });
-            if (this.calendarRef.el) {
-                this.calendarObserver.observe(this.calendarRef.el, { childList: true, subtree: true });
-            }
-
-            // Watch for Odoo form dialogs opening/closing
-            this.dialogObserver = new MutationObserver((mutations) => {
-                for (const mutation of mutations) {
-                    // Intercept dialog OPENING: redirect to our modal
-                    for (const node of mutation.addedNodes) {
-                        if (node.nodeType === 1) {
-                            const isDialog = node.classList?.contains('o_dialog') ||
-                                node.classList?.contains('modal') ||
-                                node.querySelector?.('.o_form_view') ||
-                                node.querySelector?.('.modal-dialog');
-                            if (isDialog && this.dragStartDate) {
-                                // Close the Odoo dialog
-                                const closeBtn = node.querySelector('.btn-close, .o_form_button_cancel, .close');
-                                if (closeBtn) {
-                                    closeBtn.click();
-                                } else {
-                                    node.remove();
-                                }
-                                // Open our modal with the dragged dates
-                                const startDate = this.dragStartDate;
-                                const endDate = this.dragEndDate || this.dragStartDate;
-                                // Ensure start <= end
-                                const sortedStart = startDate < endDate ? startDate : endDate;
-                                const sortedEnd = startDate < endDate ? endDate : startDate;
-                                this.dragStartDate = null;
-                                this.dragEndDate = null;
-                                this.openCreateModalWithDates(sortedStart, sortedEnd);
-                                return;
-                            }
-                        }
-                    }
-                    // Dialog CLOSING: reload products
-                    for (const node of mutation.removedNodes) {
-                        if (node.nodeType === 1) {
-                            const isDialog = node.classList?.contains('o_dialog') ||
-                                node.classList?.contains('o_technical_modal') ||
-                                node.classList?.contains('modal') ||
-                                node.classList?.contains('o_FormViewDialog') ||
-                                node.querySelector?.('.o_form_view') ||
-                                node.querySelector?.('.modal-dialog');
-                            if (isDialog) {
-                                setTimeout(() => this.loadProducts(), 300);
-                            }
-                        }
-                    }
-                }
-            });
-            this.dialogObserver.observe(document.body, { childList: true, subtree: true });
-
+            this._setupCalendarListeners();
+            this._setupTooltipElement();
+            this._setupCalendarObserver();
+            this._setupDialogObserver();
             this.state.viewLoaded = true;
         });
 
         onWillUnmount(() => {
+            // Calendar listeners
             if (this.calendarRef.el) {
-                this.calendarRef.el.removeEventListener('click', this.onCalendarClick, true);
-                this.calendarRef.el.removeEventListener('mouseover', this.onEventMouseOver);
-                this.calendarRef.el.removeEventListener('mouseout', this.onEventMouseOut);
+                this.calendarRef.el.removeEventListener(
+                    "click",
+                    this.onCalendarClick,
+                    true
+                );
+                this.calendarRef.el.removeEventListener(
+                    "mouseover",
+                    this.onEventMouseOver
+                );
+                this.calendarRef.el.removeEventListener(
+                    "mouseout",
+                    this.onEventMouseOut
+                );
             }
-            if (this.calendarObserver) {
-                this.calendarObserver.disconnect();
+            // Document-level listeners (fix memory leak)
+            if (this._onCalendarDragMove) {
+                document.removeEventListener("mousemove", this._onCalendarDragMove);
             }
-            if (this.dialogObserver) {
-                this.dialogObserver.disconnect();
+            if (this._onCalendarDragEnd) {
+                document.removeEventListener("mouseup", this._onCalendarDragEnd);
             }
-            if (this.tooltipEl) {
-                this.tooltipEl.remove();
-            }
-            if (this.tooltipTimeout) {
-                clearTimeout(this.tooltipTimeout);
-            }
+            // Observers
+            if (this.calendarObserver) this.calendarObserver.disconnect();
+            if (this.dialogObserver) this.dialogObserver.disconnect();
+            // Tooltip
+            if (this.tooltipEl) this.tooltipEl.remove();
+            if (this.tooltipTimeout) clearTimeout(this.tooltipTimeout);
+            if (this.highlightDebounce) clearTimeout(this.highlightDebounce);
         });
     }
 
-    onCalendarClick(ev) {
-        this.hideTooltip();
+    // ── Setup helpers (extracted from onMounted for readability) ──
 
-        // If clicking "+n more" link, let FC handle it
-        if (ev.target.closest('.fc-more-link, .fc-daygrid-more-link, .fc-more')) {
-            return;
-        }
+    _setupCalendarListeners() {
+        if (!this.calendarRef.el) return;
 
-        // Find if click was on a calendar event
-        const eventEl = ev.target.closest('.fc-event');
-        if (eventEl) {
-            // Stop the event from reaching the calendar's handler
-            ev.stopPropagation();
-            ev.preventDefault();
+        this.calendarRef.el.addEventListener("click", this.onCalendarClick, true);
+        this.calendarRef.el.addEventListener("mouseover", this.onEventMouseOver);
+        this.calendarRef.el.addEventListener("mouseout", this.onEventMouseOut);
 
-            // Try multiple ways to get the record ID
-            let recordId = null;
+        // Drag selection on calendar cells
+        this.calendarRef.el.addEventListener("mousedown", (ev) => {
+            const elements = document.elementsFromPoint(ev.clientX, ev.clientY);
+            if (
+                elements.some(
+                    (el) =>
+                        (el.classList && el.classList.contains("fc-event")) ||
+                        (el.closest && el.closest(".fc-event"))
+                )
+            )
+                return;
 
-            // Method 1: Check data attribute
-            recordId = eventEl.dataset.eventId || eventEl.getAttribute('data-event-id');
-
-            // Method 2: Try FullCalendar's internal data structure
-            if (!recordId && eventEl.fcSeg) {
-                const fcEvent = eventEl.fcSeg.eventRange?.def;
-                recordId = fcEvent?.publicId || fcEvent?.extendedProps?.recordId;
-            }
-
-            // Method 3: Look for fc-event link with href containing the ID
-            if (!recordId) {
-                const link = eventEl.querySelector('a[href*="id="]');
-                if (link) {
-                    const match = link.href.match(/id=(\d+)/);
-                    if (match) recordId = match[1];
+            let date = null;
+            for (const el of elements) {
+                if (el.hasAttribute && el.hasAttribute("data-date")) {
+                    date = el.getAttribute("data-date");
+                    break;
                 }
             }
+            if (date) {
+                this.dragStartDate = date;
+                this.dragEndDate = date;
+                this._isDraggingCalendar = true;
+            }
+        });
 
-            // Method 4: Check the event's title element for data
-            if (!recordId) {
-                const eventData = eventEl.__data__ || eventEl._fc_event;
-                if (eventData) {
-                    recordId = eventData.id || eventData.publicId;
+        this._onCalendarDragMove = (ev) => {
+            if (!this._isDraggingCalendar) return;
+            const elements = document.elementsFromPoint(ev.clientX, ev.clientY);
+            for (const el of elements) {
+                if (el.hasAttribute("data-date")) {
+                    this.dragEndDate = el.getAttribute("data-date");
+                    break;
                 }
             }
+        };
+        this._onCalendarDragEnd = () => {
+            this._isDraggingCalendar = false;
+        };
+        document.addEventListener("mousemove", this._onCalendarDragMove);
+        document.addEventListener("mouseup", this._onCalendarDragEnd);
+    }
 
-            if (recordId) {
-                this.openEditModal(parseInt(recordId));
-            }
+    _setupTooltipElement() {
+        this.tooltipEl = document.createElement("div");
+        this.tooltipEl.className = "rental-event-tooltip";
+        this.tooltipEl.style.display = "none";
+        document.body.appendChild(this.tooltipEl);
+    }
+
+    _setupCalendarObserver() {
+        this.highlightDebounce = null;
+        this.calendarObserver = new MutationObserver(() => {
+            if (this.highlightDebounce) clearTimeout(this.highlightDebounce);
+            this.highlightDebounce = setTimeout(
+                () => this.applyDateRangeHighlight(),
+                200
+            );
+        });
+        if (this.calendarRef.el) {
+            this.calendarObserver.observe(this.calendarRef.el, {
+                childList: true,
+                subtree: true,
+            });
         }
     }
 
-    onEventMouseOver(ev) {
-        const eventEl = ev.target.closest('.fc-event');
-        if (!eventEl) return;
+    _setupDialogObserver() {
+        this.dialogObserver = new MutationObserver((mutations) => {
+            for (const mutation of mutations) {
+                for (const node of mutation.addedNodes) {
+                    if (node.nodeType !== 1) continue;
+                    if (this._isOdooDialog(node) && this.dragStartDate) {
+                        const closeBtn = node.querySelector(
+                            ".btn-close, .o_form_button_cancel, .close"
+                        );
+                        if (closeBtn) {
+                            closeBtn.click();
+                        } else {
+                            node.remove();
+                        }
+                        const start = this.dragStartDate;
+                        const end = this.dragEndDate || this.dragStartDate;
+                        const sortedStart = start < end ? start : end;
+                        const sortedEnd = start < end ? end : start;
+                        this.dragStartDate = null;
+                        this.dragEndDate = null;
+                        this.openCreateModalWithDates(sortedStart, sortedEnd);
+                        return;
+                    }
+                }
+                for (const node of mutation.removedNodes) {
+                    if (node.nodeType !== 1) continue;
+                    if (this._isOdooDialog(node)) {
+                        setTimeout(() => this.loadProducts(), 300);
+                    }
+                }
+            }
+        });
+        this.dialogObserver.observe(document.body, {childList: true, subtree: true});
+    }
 
-        if (this.state.showModal) return;
+    _isOdooDialog(node) {
+        return (
+            node.classList?.contains("o_dialog") ||
+            node.classList?.contains("modal") ||
+            node.classList?.contains("o_technical_modal") ||
+            node.classList?.contains("o_FormViewDialog") ||
+            node.querySelector?.(".o_form_view") ||
+            node.querySelector?.(".modal-dialog")
+        );
+    }
 
-        let recordId = eventEl.dataset.eventId || eventEl.getAttribute('data-event-id');
+    // ── Event handlers ──
+
+    _getRecordIdFromEvent(eventEl) {
+        let recordId = eventEl.dataset.eventId || eventEl.getAttribute("data-event-id");
         if (!recordId && eventEl.fcSeg) {
             const fcEvent = eventEl.fcSeg.eventRange?.def;
             recordId = fcEvent?.publicId || fcEvent?.extendedProps?.recordId;
         }
+        if (!recordId) {
+            const link = eventEl.querySelector('a[href*="id="]');
+            if (link) {
+                const match = link.href.match(/id=(\d+)/);
+                if (match) recordId = match[1];
+            }
+        }
+        if (!recordId) {
+            const eventData = eventEl.__data__ || eventEl._fc_event;
+            if (eventData) recordId = eventData.id || eventData.publicId;
+        }
+        return recordId;
+    }
 
+    onCalendarClick(ev) {
+        this.hideTooltip();
+        if (ev.target.closest(".fc-more-link, .fc-daygrid-more-link, .fc-more")) return;
+
+        const eventEl = ev.target.closest(".fc-event");
+        if (eventEl) {
+            ev.stopPropagation();
+            ev.preventDefault();
+            const recordId = this._getRecordIdFromEvent(eventEl);
+            if (recordId) this.openEditModal(parseInt(recordId));
+        }
+    }
+
+    onEventMouseOver(ev) {
+        const eventEl = ev.target.closest(".fc-event");
+        if (!eventEl || this.state.showModal) return;
+
+        const recordId = this._getRecordIdFromEvent(eventEl);
         if (!recordId) return;
 
-        // Already showing for this event
-        if (this.currentHoveredEventId === recordId && this.tooltipEl.style.display !== 'none') {
+        if (
+            this.currentHoveredEventId === recordId &&
+            this.tooltipEl.style.display !== "none"
+        )
             return;
-        }
 
         if (this.tooltipTimeout) {
             clearTimeout(this.tooltipTimeout);
@@ -280,369 +308,177 @@ export class RentalDashboard extends Component {
 
         this.currentHoveredEventId = recordId;
 
-        this.orm.searchRead(
-            "sale.order.line",
-            [["id", "=", parseInt(recordId)]],
-            ["id", "product_id", "start_datetime", "end_datetime", "order_partner_id", "order_id", "rental_qty", "state"]
-        ).then(([soLine]) => {
-            if (this.currentHoveredEventId !== recordId) return;
-            if (this.state.showModal) return;
+        // Use cached data if available
+        if (this.tooltipCache.has(recordId)) {
+            this._showTooltip(eventEl, this.tooltipCache.get(recordId));
+        } else {
+            this.orm
+                .searchRead(
+                    "sale.order.line",
+                    [["id", "=", parseInt(recordId)]],
+                    [
+                        "id",
+                        "product_id",
+                        "start_datetime",
+                        "end_datetime",
+                        "order_partner_id",
+                        "order_id",
+                        "rental_qty",
+                        "state",
+                    ]
+                )
+                .then(([soLine]) => {
+                    if (this.currentHoveredEventId !== recordId) return;
+                    if (this.state.showModal) return;
+                    if (soLine) {
+                        this.tooltipCache.set(recordId, soLine);
+                        this._showTooltip(eventEl, soLine);
+                    }
+                });
+        }
+    }
 
-            if (soLine) {
-                const rect = eventEl.getBoundingClientRect();
-                const productName = soLine.product_id ? soLine.product_id[1] : 'No product';
-                const startDate = this.formatTooltipDate(soLine.start_datetime);
-                const endDate = this.formatTooltipDate(soLine.end_datetime);
-                const customer = soLine.order_partner_id ? soLine.order_partner_id[1] : 'No customer';
-                const orderName = soLine.order_id ? soLine.order_id[1] : '';
+    _showTooltip(eventEl, soLine) {
+        const rect = eventEl.getBoundingClientRect();
+        const productName = soLine.product_id ? soLine.product_id[1] : "No product";
+        const startDate = this._formatTooltipDate(soLine.start_datetime);
+        const endDate = this._formatTooltipDate(soLine.end_datetime);
+        const customer = soLine.order_partner_id
+            ? soLine.order_partner_id[1]
+            : "No customer";
+        const orderName = soLine.order_id ? soLine.order_id[1] : "";
 
-                this.tooltipEl.innerHTML = `
-                    <div class="tooltip-content">
-                        <div class="tooltip-title fw-bold mb-2">${_.escape(productName)}</div>
-                        <div class="tooltip-dates mb-2">${_.escape(startDate)} - ${_.escape(endDate)}</div>
-                        <div class="tooltip-info">
-                            <div class="d-flex align-items-center mb-1">
-                                <i class="fa fa-file-text-o me-2 text-muted"></i>
-                                <span>${_.escape(orderName)}</span>
-                            </div>
-                            <div class="d-flex align-items-center mb-1">
-                                <i class="fa fa-user me-2 text-muted"></i>
-                                <span>${_.escape(customer)}</span>
-                            </div>
-                            <div class="d-flex align-items-center">
-                                <i class="fa fa-cubes me-2 text-muted"></i>
-                                <span>Qty: ${soLine.rental_qty}</span>
-                            </div>
-                        </div>
-                    </div>`;
-                this.tooltipEl.style.left = (rect.left + rect.width / 2) + 'px';
-                this.tooltipEl.style.top = (rect.top - 10) + 'px';
-                this.tooltipEl.style.display = '';
-            }
-        });
+        this.tooltipEl.innerHTML = `
+            <div class="tooltip-content">
+                <div class="tooltip-title fw-bold mb-2">${_.escape(productName)}</div>
+                <div class="tooltip-dates mb-2">${_.escape(startDate)} - ${_.escape(
+            endDate
+        )}</div>
+                <div class="tooltip-info">
+                    <div class="d-flex align-items-center mb-1">
+                        <i class="fa fa-file-text-o me-2 text-muted"></i>
+                        <span>${_.escape(orderName)}</span>
+                    </div>
+                    <div class="d-flex align-items-center mb-1">
+                        <i class="fa fa-user me-2 text-muted"></i>
+                        <span>${_.escape(customer)}</span>
+                    </div>
+                    <div class="d-flex align-items-center">
+                        <i class="fa fa-cubes me-2 text-muted"></i>
+                        <span>Qty: ${soLine.rental_qty}</span>
+                    </div>
+                </div>
+            </div>`;
+        this.tooltipEl.style.left = rect.left + rect.width / 2 + "px";
+        this.tooltipEl.style.top = rect.top - 10 + "px";
+        this.tooltipEl.style.display = "";
     }
 
     onEventMouseOut(ev) {
-        const eventEl = ev.target.closest('.fc-event');
+        const eventEl = ev.target.closest(".fc-event");
         if (!eventEl) return;
-
-        const relatedTarget = ev.relatedTarget;
-        if (relatedTarget && eventEl.contains(relatedTarget)) {
-            return;
-        }
+        if (ev.relatedTarget && eventEl.contains(ev.relatedTarget)) return;
 
         this.tooltipTimeout = setTimeout(() => {
-            if (this.tooltipEl) this.tooltipEl.style.display = 'none';
+            if (this.tooltipEl) this.tooltipEl.style.display = "none";
             this.currentHoveredEventId = null;
         }, 100);
     }
 
     hideTooltip() {
-        if (this.tooltipTimeout) {
-            clearTimeout(this.tooltipTimeout);
-        }
-        if (this.tooltipEl) this.tooltipEl.style.display = 'none';
+        if (this.tooltipTimeout) clearTimeout(this.tooltipTimeout);
+        if (this.tooltipEl) this.tooltipEl.style.display = "none";
         this.currentHoveredEventId = null;
     }
 
-    formatTooltipDate(dateStr) {
-        if (!dateStr) return '';
+    _formatTooltipDate(dateStr) {
+        if (!dateStr) return "";
         const date = new Date(dateStr);
-        const month = date.getMonth() + 1;
-        const day = date.getDate();
-        const year = String(date.getFullYear()).slice(-2);
-        return `${month}/${day}/${year}`;
+        return `${date.getMonth() + 1}/${date.getDate()}/${String(
+            date.getFullYear()
+        ).slice(-2)}`;
     }
 
-    async loadRentalPeriods() {
-        this.state.rentalPeriods = await this.orm.searchRead(
-            "rental.period",
-            [["active", "=", true]],
-            ["id", "name", "code", "hours_per_unit"],
-            {order: "sequence, id"}
-        );
-    }
-
-    async loadLocations() {
-        // Load only rental_in locations from rental-enabled warehouses
-        const warehouses = await this.orm.searchRead(
-            "stock.warehouse",
-            [["rental_allowed", "=", true]],
-            ["id", "name", "rental_in_location_id", "rental_out_location_id"]
-        );
-        this.state.warehouses = warehouses;
-        this.state.locations = warehouses.map(wh => ({
-            id: wh.rental_in_location_id[0],
-            name: wh.rental_in_location_id[1],
-            display_name: wh.name,
-            rental_out_location_id: wh.rental_out_location_id[0],
-            warehouse_id: wh.id,
-        }));
-    }
+    // ── Data loading ──
 
     async loadProducts() {
-        // Physical products that have a rental service linked
-        const domain = [["rental_service_ids", "!=", false]];
-
-        // Collect rental_in and rental_out location IDs
-        let rentalInIds = [];
-        let rentalOutIds = [];
-
-        if (this.state.selectedLocation) {
-            // Single selected rental_in location
-            rentalInIds = [this.state.selectedLocation];
-            const loc = this.state.locations.find(l => l.id === this.state.selectedLocation);
-            rentalOutIds = loc ? [loc.rental_out_location_id] : [];
-        } else {
-            // All rental locations
-            rentalInIds = this.state.locations.map(l => l.id);
-            rentalOutIds = this.state.locations.map(l => l.rental_out_location_id);
-        }
-
-        const allLocationIds = [...rentalInIds, ...rentalOutIds];
-
-        // Get stock at rental locations
-        const quants = await this.orm.searchRead(
-            "stock.quant",
-            [
-                ["location_id", "in", allLocationIds],
-                ["quantity", ">", 0],
-            ],
-            ["product_id", "quantity", "location_id"]
-        );
-        // Build maps: rental_in qty (available) and total qty (rental_in + rental_out)
-        const rentalInQtyMap = {};
-        const totalQtyMap = {};
-        quants.forEach(q => {
-            const pid = q.product_id[0];
-            const qty = q.quantity;
-            totalQtyMap[pid] = (totalQtyMap[pid] || 0) + qty;
-            if (rentalInIds.includes(q.location_id[0])) {
-                rentalInQtyMap[pid] = (rentalInQtyMap[pid] || 0) + qty;
-            }
-        });
-
-
-        // Get committed rental qty from active sale.rental records
-        // "ordered" = confirmed but not yet picked from rental_in
-        // Filter by out_picking_id.location_id to match selected location(s)
-        // Filter by date range overlap if dates are selected
-        const rentalDomain = [["state", "=", "ordered"]];
-        if (rentalInIds.length > 0) {
-            rentalDomain.push(["out_picking_id.location_id", "in", rentalInIds]);
-        }
-        if (this.state.dateFrom) {
-            rentalDomain.push(["start_datetime", "<=", this.state.dateTo || this.state.dateFrom]);
-        }
-        if (this.state.dateTo) {
-            rentalDomain.push(["end_datetime", ">=", this.state.dateFrom || this.state.dateTo]);
-        }
-        const rentals = await this.orm.searchRead(
-            "sale.rental",
-            rentalDomain,
-            ["rented_product_id", "rental_qty"]
-        );
-        const committedQtyMap = {};
-        rentals.forEach(r => {
-            const pid = r.rented_product_id[0];
-            committedQtyMap[pid] = (committedQtyMap[pid] || 0) + r.rental_qty;
-        });
-
-        // If location selected, filter to products with stock at those locations
-        const productIdsAtLocation = Object.keys(totalQtyMap).map(Number);
-        if (this.state.selectedLocation) {
-            if (productIdsAtLocation.length > 0) {
-                domain.push(["id", "in", productIdsAtLocation]);
-            } else {
-                this.state.products = [];
-                return;
-            }
-        }
-
-        const products = await this.orm.searchRead(
+        // Single RPC replaces 3 separate searchRead calls
+        const products = await this.orm.call(
             "product.product",
-            domain,
-            ["id", "name", "default_code", "rental_color"]
-        );
-
-        // qty_total = rental_in + rental_out (total fleet)
-        // qty_available = rental_in - committed rental qty (truly available)
-        products.forEach(p => {
-            p.qty_total = totalQtyMap[p.id] || 0;
-            const rentalInQty = rentalInQtyMap[p.id] || 0;
-            const committed = committedQtyMap[p.id] || 0;
-            p.qty_available = Math.max(0, rentalInQty - committed);
-
-            if (p.qty_available > 5) {
-                p.availability_status = 'available';
-            } else if (p.qty_available > 0) {
-                p.availability_status = 'low';
-            } else {
-                p.availability_status = 'unavailable';
+            "get_rental_products",
+            [],
+            {
+                location_id: this.state.selectedLocation,
+                date_from: this.state.dateFrom,
+                date_to: this.state.dateTo,
             }
-        });
+        );
         this.state.products = products;
     }
 
     async loadModalProducts() {
-        const locationId = this.state.modalData.locationId;
-
-        // Determine rental_in location(s)
-        let rentalInIds = [];
-        if (locationId) {
-            rentalInIds = [locationId];
-        } else {
-            rentalInIds = this.state.locations.map(l => l.id);
-        }
-
-        // Get stock at rental_in location(s) for physical products
-        const quants = await this.orm.searchRead(
-            "stock.quant",
-            [
-                ["location_id", "in", rentalInIds],
-                ["quantity", ">", 0],
-            ],
-            ["product_id", "quantity"]
-        );
-        const rentalInQtyMap = {};
-        quants.forEach(q => {
-            const pid = q.product_id[0];
-            rentalInQtyMap[pid] = (rentalInQtyMap[pid] || 0) + q.quantity;
-        });
-
-        // Get committed rental qty filtered by location
-        const rentalDomain = [["state", "=", "ordered"]];
-        if (rentalInIds.length > 0) {
-            rentalDomain.push(["out_picking_id.location_id", "in", rentalInIds]);
-        }
-        const rentals = await this.orm.searchRead(
-            "sale.rental",
-            rentalDomain,
-            ["rented_product_id", "rental_qty"]
-        );
-        const committedQtyMap = {};
-        rentals.forEach(r => {
-            const pid = r.rented_product_id[0];
-            committedQtyMap[pid] = (committedQtyMap[pid] || 0) + r.rental_qty;
-        });
-
-        // Load physical products to get their rental_service_ids
-        const physicalDomain = [["rental_service_ids", "!=", false]];
-        if (locationId) {
-            const productIdsAtLocation = Object.keys(rentalInQtyMap).map(Number);
-            if (productIdsAtLocation.length > 0) {
-                physicalDomain.push(["id", "in", productIdsAtLocation]);
-            } else {
-                this.state.modalProducts = [];
-                return;
-            }
-        }
-
-        const physicalProducts = await this.orm.searchRead(
+        // Single RPC replaces 4+ separate searchRead calls
+        // Also includes pricings so no separate pricing lookups needed
+        this.state.modalProducts = await this.orm.call(
             "product.product",
-            physicalDomain,
-            ["id", "name", "rental_service_ids"]
+            "get_rental_modal_products",
+            [],
+            {location_id: this.state.modalData.locationId}
         );
-
-        // Build availability map for physical products
-        const availMap = {};
-        physicalProducts.forEach(p => {
-            const rentalInQty = rentalInQtyMap[p.id] || 0;
-            const committed = committedQtyMap[p.id] || 0;
-            availMap[p.id] = Math.max(0, rentalInQty - committed);
-        });
-
-        // Collect all rental service IDs
-        const allServiceIds = [];
-        physicalProducts.forEach(p => {
-            allServiceIds.push(...p.rental_service_ids);
-        });
-
-        if (allServiceIds.length === 0) {
-            this.state.modalProducts = [];
-            return;
-        }
-
-        // Load service products
-        const serviceProducts = await this.orm.searchRead(
-            "product.product",
-            [["id", "in", allServiceIds]],
-            ["id", "name", "rented_product_id"]
-        );
-
-        // Attach physical product availability to each service product
-        serviceProducts.forEach(sp => {
-            const physicalId = sp.rented_product_id ? sp.rented_product_id[0] : null;
-            sp.physicalProductId = physicalId;
-            sp.qty_available = physicalId ? (availMap[physicalId] || 0) : 0;
-        });
-
-        this.state.modalProducts = serviceProducts;
     }
 
     get filteredProducts() {
         let products = this.state.products;
-
         if (this.state.showAvailableOnly) {
-            products = products.filter(p => p.qty_available > 0);
+            products = products.filter((p) => p.qty_available > 0);
         }
-
         return products;
     }
 
     get calendarDomain() {
-        // Only rental SO lines, exclude cancelled orders
         const domain = [
             ["rental", "=", true],
             ["state", "not in", ["cancel"]],
         ];
 
-        // Filter by warehouse matching the selected rental_in location
         if (this.state.selectedLocation) {
-            const loc = this.state.locations.find(l => l.id === this.state.selectedLocation);
-            if (loc) {
-                domain.push(["order_id.warehouse_id", "=", loc.warehouse_id]);
-            }
+            const loc = this.state.locations.find(
+                (l) => l.id === this.state.selectedLocation
+            );
+            if (loc) domain.push(["order_id.warehouse_id", "=", loc.warehouse_id]);
         }
-
-        // Filter by date range (overlapping)
-        if (this.state.dateFrom) {
+        if (this.state.dateFrom)
             domain.push(["end_datetime", ">=", this.state.dateFrom]);
-        }
-        if (this.state.dateTo) {
-            domain.push(["start_datetime", "<=", this.state.dateTo]);
-        }
-
-        // Filter by selected products (physical) via rental_service_ids
+        if (this.state.dateTo) domain.push(["start_datetime", "<=", this.state.dateTo]);
         if (this.state.selectedProducts.length > 0) {
-            domain.push(["product_id.rented_product_id", "in", this.state.selectedProducts]);
+            domain.push([
+                "product_id.rented_product_id",
+                "in",
+                this.state.selectedProducts,
+            ]);
         }
-
         return domain;
     }
 
     get calendarProps() {
         if (!this.state.viewLoaded) return null;
-
         return {
             resModel: "sale.order.line",
             type: "calendar",
             domain: this.calendarDomain,
             context: this.props.context || {},
-            display: {
-                // controlPanel: false,
-            },
+            display: {},
         };
     }
 
+    // ── Filter actions ──
 
-    // Actions
     async onLocationChange(ev) {
         const value = ev.target.value;
         this.state.selectedLocation = value ? parseInt(value) : null;
-        this.state.selectedProducts = []; // Clear product selection when location changes
-        await this.loadProducts(); // Reload products for new location
-        this.state.calendarKey++; // Force calendar re-render
+        this.state.selectedProducts = [];
+        await this.loadProducts();
+        this._refreshCalendar();
     }
 
     onShowAvailableChange(ev) {
@@ -656,7 +492,7 @@ export class RentalDashboard extends Component {
         } else {
             this.state.selectedProducts.push(productId);
         }
-        this.state.calendarKey++; // Force calendar re-render
+        this._refreshCalendar();
     }
 
     isProductSelected(productId) {
@@ -670,11 +506,12 @@ export class RentalDashboard extends Component {
         this.state.showDatePicker = false;
         this.state.showAvailableOnly = false;
         this.state.selectedProducts = [];
-        await this.loadProducts(); // Reload all products
-        this.state.calendarKey++;
+        await this.loadProducts();
+        this._refreshCalendar();
     }
 
-    // Date filter functions
+    // ── Date filter ──
+
     toggleDatePicker() {
         this.state.showDatePicker = !this.state.showDatePicker;
     }
@@ -689,9 +526,8 @@ export class RentalDashboard extends Component {
 
     async applyDateFilter() {
         this.state.showDatePicker = false;
-        this.state.calendarKey++;
-        await this.loadProducts(); // Recalculate availability based on date range
-        // Delay to let calendar re-render, then highlight
+        this._refreshCalendar();
+        await this.loadProducts();
         setTimeout(() => this.applyDateRangeHighlight(), 500);
     }
 
@@ -699,242 +535,211 @@ export class RentalDashboard extends Component {
         this.state.dateFrom = null;
         this.state.dateTo = null;
         this.state.showDatePicker = false;
-        this.state.calendarKey++;
-        await this.loadProducts(); // Recalculate availability
+        this._refreshCalendar();
+        await this.loadProducts();
         this.applyDateRangeHighlight();
     }
 
     applyDateRangeHighlight() {
         if (!this.calendarRef.el) return;
 
-        // Try multiple selectors for different FullCalendar versions
-        let dayCells = this.calendarRef.el.querySelectorAll('.fc-daygrid-day[data-date]');
-        if (!dayCells.length) {
-            dayCells = this.calendarRef.el.querySelectorAll('td[data-date]');
-        }
-        if (!dayCells.length) {
-            dayCells = this.calendarRef.el.querySelectorAll('.fc-day[data-date]');
-        }
+        let dayCells = this.calendarRef.el.querySelectorAll(
+            ".fc-daygrid-day[data-date]"
+        );
+        if (!dayCells.length)
+            dayCells = this.calendarRef.el.querySelectorAll("td[data-date]");
+        if (!dayCells.length)
+            dayCells = this.calendarRef.el.querySelectorAll(".fc-day[data-date]");
         if (!dayCells.length) return;
 
-        // Remove existing classes first
-        dayCells.forEach(cell => {
-            cell.classList.remove('date-in-range', 'date-outside-range');
-        });
+        dayCells.forEach((cell) =>
+            cell.classList.remove("date-in-range", "date-outside-range")
+        );
 
-        // If no date range selected, don't highlight anything
         if (!this.state.dateFrom || !this.state.dateTo) return;
 
-        const fromDate = new Date(this.state.dateFrom + 'T00:00:00');
-        const toDate = new Date(this.state.dateTo + 'T23:59:59');
+        const fromDate = new Date(this.state.dateFrom + "T00:00:00");
+        const toDate = new Date(this.state.dateTo + "T23:59:59");
 
-        dayCells.forEach(cell => {
-            const dateAttr = cell.getAttribute('data-date');
+        dayCells.forEach((cell) => {
+            const dateAttr = cell.getAttribute("data-date");
             if (!dateAttr) return;
-
-            const cellDate = new Date(dateAttr + 'T12:00:00');
-
-            if (cellDate >= fromDate && cellDate <= toDate) {
-                cell.classList.add('date-in-range');
-            } else {
-                cell.classList.add('date-outside-range');
-            }
+            const cellDate = new Date(dateAttr + "T12:00:00");
+            cell.classList.add(
+                cellDate >= fromDate && cellDate <= toDate
+                    ? "date-in-range"
+                    : "date-outside-range"
+            );
         });
     }
 
     formatDateRange() {
-        if (!this.state.dateFrom || !this.state.dateTo) return '';
-
+        if (!this.state.dateFrom || !this.state.dateTo) return "";
         const from = new Date(this.state.dateFrom);
         const to = new Date(this.state.dateTo);
-
-        // Calculate days difference
-        const diffTime = Math.abs(to - from);
-        const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24)) + 1;
-
-        // Format dates as M/D/YY
-        const formatDate = (date) => {
-            const month = date.getMonth() + 1;
-            const day = date.getDate();
-            const year = String(date.getFullYear()).slice(-2);
-            return `${month}/${day}/${year}`;
-        };
-
-        return `${formatDate(from)} - ${formatDate(to)} (${diffDays} days)`;
+        const diffDays = Math.ceil(Math.abs(to - from) / (1000 * 60 * 60 * 24)) + 1;
+        const fmt = (d) =>
+            `${d.getMonth() + 1}/${d.getDate()}/${String(d.getFullYear()).slice(-2)}`;
+        return `${fmt(from)} - ${fmt(to)} (${diffDays} days)`;
     }
 
-    // Modal functions
+    // ── Calendar helpers ──
+
+    _refreshCalendar() {
+        this.tooltipCache.clear();
+        this.state.calendarKey++;
+    }
+
+    // ── Modal: create ──
+
     async openCreateModal() {
-        this.state.modalMode = 'create';
+        this.state.modalMode = "create";
         this.state.editingOrderId = null;
         this.state.modalData = {
             locationId: this.state.selectedLocation,
             customerId: null,
-            customerSearch: '',
-            startDate: this.state.dateFrom || this.formatDateForInput(new Date()),
-            endDate: this.state.dateTo || this.formatDateForInput(new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)),
+            customerSearch: "",
+            startDate: this.state.dateFrom || this._formatDateForInput(new Date()),
+            endDate:
+                this.state.dateTo ||
+                this._formatDateForInput(
+                    new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+                ),
             state: null,
             lines: [],
         };
 
         await this.loadModalProducts();
 
-        // Initialize lines from pre-selected physical products (sidebar)
-        // Map physical product IDs to their service products
+        // Build lines from pre-selected products (synchronous — pricings are cached)
         const lines = [];
-        if (this.state.selectedProducts.length > 0) {
-            for (const physicalId of this.state.selectedProducts) {
-                // Find the first service product for this physical product
-                const service = this.state.modalProducts.find(p => p.physicalProductId === physicalId);
-                if (service) {
-                    // Load available periods from product.rental.pricing
-                    const pricings = await this.orm.searchRead(
-                        "product.rental.pricing",
-                        [["product_id", "=", service.id]],
-                        ["period_id"]
-                    );
-                    const availablePeriodIds = pricings.map(p => p.period_id[0]);
-                    const rentalPeriodId = availablePeriodIds.length > 0 ? availablePeriodIds[0] : null;
-                    const priceUnit = rentalPeriodId ? await this.computePriceUnit(service.id, rentalPeriodId) : 0;
-
-                    lines.push({
-                        id: Date.now() + Math.random(),
-                        productId: service.id,
-                        rentalType: 'new_rental',
-                        rentalPeriodId: rentalPeriodId,
-                        availablePeriodIds: availablePeriodIds,
-                        rentalQty: 1,
-                        priceUnit: priceUnit,
-                        available: service.qty_available || 0,
-                    });
-                }
+        for (const physicalId of this.state.selectedProducts) {
+            const service = this.state.modalProducts.find(
+                (p) => p.physicalProductId === physicalId
+            );
+            if (service) {
+                const availablePeriodIds = service.pricings.map((p) => p.period_id);
+                const rentalPeriodId =
+                    availablePeriodIds.length > 0 ? availablePeriodIds[0] : null;
+                const priceUnit = rentalPeriodId
+                    ? this._computePriceUnit(service.id, rentalPeriodId)
+                    : 0;
+                lines.push({
+                    id: Date.now() + Math.random(),
+                    productId: service.id,
+                    rentalType: "new_rental",
+                    rentalPeriodId,
+                    availablePeriodIds,
+                    rentalQty: 1,
+                    priceUnit,
+                    available: service.qty_available || 0,
+                });
             }
         }
 
-        this.state.modalData.lines = lines.length > 0 ? lines : [this.createEmptyLine()];
-
+        this.state.modalData.lines =
+            lines.length > 0 ? lines : [this._createEmptyLine()];
         this.hideTooltip();
         this.state.showModal = true;
     }
 
     async openCreateModalWithDates(startDate, endDate) {
-        this.state.modalMode = 'create';
+        this.state.modalMode = "create";
         this.state.editingOrderId = null;
         this.state.modalData = {
             locationId: this.state.selectedLocation,
             customerId: null,
-            customerSearch: '',
-            startDate: startDate,
-            endDate: endDate,
+            customerSearch: "",
+            startDate,
+            endDate,
             state: null,
             lines: [],
         };
 
         await this.loadModalProducts();
-        this.state.modalData.lines = [this.createEmptyLine()];
-
+        this.state.modalData.lines = [this._createEmptyLine()];
         this.hideTooltip();
         this.state.showModal = true;
     }
 
+    // ── Modal: edit ──
+
     async openEditModal(soLineId) {
         try {
-            // Load the SO line to get order_id
-            const [soLine] = await this.orm.searchRead(
+            // Single RPC replaces 3 sequential RPCs + loadModalProducts (4+ RPCs)
+            const data = await this.orm.call(
                 "sale.order.line",
-                [["id", "=", soLineId]],
-                ["order_id"]
+                "get_rental_order_edit_data",
+                [soLineId]
             );
-            if (!soLine) {
+            if (!data) {
                 console.error("SO line not found:", soLineId);
                 return;
             }
 
-            const orderId = soLine.order_id[0];
+            const {order, lines: orderLines, location_id, modal_products} = data;
+            this.state.modalProducts = modal_products;
 
-            // Load the sale order
-            const [order] = await this.orm.searchRead(
-                "sale.order",
-                [["id", "=", orderId]],
-                ["id", "partner_id", "warehouse_id", "state"]
-            );
-            if (!order) {
-                console.error("Sale order not found:", orderId);
-                return;
-            }
-
-            // Find location from warehouse
-            const loc = this.state.locations.find(l => l.warehouse_id === order.warehouse_id[0]);
-
-            // Load all rental SO lines for this order
-            const orderLines = await this.orm.searchRead(
-                "sale.order.line",
-                [["order_id", "=", orderId], ["rental", "=", true]],
-                ["id", "product_id", "rental_type", "rental_period_id", "rental_qty",
-                 "price_unit", "start_datetime", "end_datetime"]
-            );
-
-            // Use dates from first line
+            const loc = this.state.locations.find((l) => l.id === location_id);
             const firstLine = orderLines[0];
-            const startDt = firstLine ? firstLine.start_datetime : null;
-            const endDt = firstLine ? firstLine.end_datetime : null;
 
-            // Set up modal data (need locationId for loadModalProducts)
-            this.state.modalMode = 'edit';
-            this.state.editingOrderId = orderId;
+            this.state.modalMode = "edit";
+            this.state.editingOrderId = order.id;
             this.state.modalData = {
-                locationId: loc ? loc.id : null,
+                locationId: location_id,
                 customerId: order.partner_id[0],
                 customerSearch: order.partner_id[1],
-                startDate: startDt ? startDt.split(' ')[0] : null,
-                endDate: endDt ? endDt.split(' ')[0] : null,
+                startDate: firstLine?.start_datetime
+                    ? firstLine.start_datetime.split(" ")[0]
+                    : null,
+                endDate: firstLine?.end_datetime
+                    ? firstLine.end_datetime.split(" ")[0]
+                    : null,
                 state: order.state,
                 lines: [],
             };
 
-            await this.loadModalProducts();
-
-            // Map SO lines: product_id is the service product directly
-            const lines = [];
-            for (const line of orderLines) {
+            // Map SO lines — pricings come from modal_products (no extra RPCs)
+            const modalLines = orderLines.map((line) => {
                 const serviceProductId = line.product_id[0];
-                const modalProduct = this.state.modalProducts.find(p => p.id === serviceProductId);
-
-                // Load available periods from product.rental.pricing
-                const pricings = await this.orm.searchRead(
-                    "product.rental.pricing",
-                    [["product_id", "=", serviceProductId]],
-                    ["period_id"]
+                const modalProduct = modal_products.find(
+                    (p) => p.id === serviceProductId
                 );
+                const availablePeriodIds = modalProduct
+                    ? modalProduct.pricings.map((p) => p.period_id)
+                    : [];
 
-                lines.push({
+                return {
                     id: line.id,
                     productId: serviceProductId,
                     rentalType: line.rental_type,
-                    rentalPeriodId: line.rental_period_id ? line.rental_period_id[0] : null,
-                    availablePeriodIds: pricings.map(p => p.period_id[0]),
+                    rentalPeriodId: line.rental_period_id
+                        ? line.rental_period_id[0]
+                        : null,
+                    availablePeriodIds,
                     rentalQty: line.rental_qty,
                     priceUnit: line.price_unit,
                     available: modalProduct ? modalProduct.qty_available : 0,
-                });
-            }
+                };
+            });
 
-            this.state.modalData.lines = lines.length > 0 ? lines : [this.createEmptyLine()];
-
+            this.state.modalData.lines =
+                modalLines.length > 0 ? modalLines : [this._createEmptyLine()];
             this.hideTooltip();
             this.state.showModal = true;
-
         } catch (error) {
             console.error("Error loading sale order:", error);
             alert("Error loading rental data. Please try again.");
         }
     }
 
-    createEmptyLine() {
+    // ── Modal: shared ──
+
+    _createEmptyLine() {
         return {
             id: Date.now() + Math.random(),
-            productId: null,       // service product ID (sale.order.line.product_id)
-            rentalType: 'new_rental',
+            productId: null,
+            rentalType: "new_rental",
             rentalPeriodId: null,
             availablePeriodIds: [],
             rentalQty: 1,
@@ -962,9 +767,11 @@ export class RentalDashboard extends Component {
     async confirmEditingOrder() {
         if (!this.state.editingOrderId) return;
         try {
-            await this.orm.call("sale.order", "action_confirm", [this.state.editingOrderId]);
-            this.state.modalData.state = 'sale';
-            this.state.calendarKey++;
+            await this.orm.call("sale.order", "action_confirm", [
+                this.state.editingOrderId,
+            ]);
+            this.state.modalData.state = "sale";
+            this._refreshCalendar();
             await this.loadProducts();
         } catch (error) {
             console.error("Error confirming order:", error);
@@ -986,10 +793,12 @@ export class RentalDashboard extends Component {
     async confirmCreatedOrder() {
         if (!this.state.createdOrderId) return;
         try {
-            await this.orm.call("sale.order", "action_confirm", [this.state.createdOrderId]);
+            await this.orm.call("sale.order", "action_confirm", [
+                this.state.createdOrderId,
+            ]);
             this.state.showModal = false;
             this.state.createdOrderId = null;
-            this.state.calendarKey++;
+            this._refreshCalendar();
             await this.loadProducts();
         } catch (error) {
             console.error("Error confirming order:", error);
@@ -997,20 +806,22 @@ export class RentalDashboard extends Component {
         }
     }
 
-    formatDateForInput(date) {
-        return date.toISOString().split('T')[0];
+    _formatDateForInput(date) {
+        return date.toISOString().split("T")[0];
     }
 
+    // ── Modal: field handlers ──
+
     async onModalLocationChange(ev) {
-        this.state.modalData.locationId = ev.target.value ? parseInt(ev.target.value) : null;
-        // Reload products for the new location
+        this.state.modalData.locationId = ev.target.value
+            ? parseInt(ev.target.value)
+            : null;
         await this.loadModalProducts();
     }
 
     async onCustomerSearch(ev) {
         const search = ev.target.value;
         this.state.modalData.customerSearch = search;
-
         if (search.length >= 2) {
             this.state.customers = await this.orm.searchRead(
                 "res.partner",
@@ -1037,7 +848,9 @@ export class RentalDashboard extends Component {
         this.state.modalData.endDate = ev.target.value;
     }
 
-    async onLineProductChange(line, ev) {
+    // ── Modal: line handlers (now synchronous — no RPC calls) ──
+
+    onLineProductChange(line, ev) {
         const productId = ev.target.value ? parseInt(ev.target.value) : null;
         line.productId = productId;
         line.availablePeriodIds = [];
@@ -1045,42 +858,39 @@ export class RentalDashboard extends Component {
         line.priceUnit = 0;
 
         if (productId) {
-            const product = this.state.modalProducts.find(p => p.id === productId);
+            const product = this.state.modalProducts.find((p) => p.id === productId);
             if (product) {
                 line.available = product.qty_available || 0;
-
-                // Load available periods from product.rental.pricing
-                const pricings = await this.orm.searchRead(
-                    "product.rental.pricing",
-                    [["product_id", "=", productId]],
-                    ["period_id"]
-                );
-                line.availablePeriodIds = pricings.map(p => p.period_id[0]);
-
-                // Auto-select first available period
+                line.availablePeriodIds = product.pricings.map((p) => p.period_id);
                 if (line.availablePeriodIds.length > 0) {
                     line.rentalPeriodId = line.availablePeriodIds[0];
-                    line.priceUnit = await this.computePriceUnit(productId, line.rentalPeriodId);
+                    line.priceUnit = this._computePriceUnit(
+                        productId,
+                        line.rentalPeriodId
+                    );
                 }
             }
         }
     }
 
     getLineAvailablePeriods(line) {
-        if (!line.availablePeriodIds || line.availablePeriodIds.length === 0) {
-            return [];
-        }
-        return this.state.rentalPeriods.filter(p => line.availablePeriodIds.includes(p.id));
+        if (!line.availablePeriodIds || line.availablePeriodIds.length === 0) return [];
+        return this.state.rentalPeriods.filter((p) =>
+            line.availablePeriodIds.includes(p.id)
+        );
     }
 
     onLineRentalTypeChange(line, ev) {
-        line.rentalType = ev.target.value || 'new_rental';
+        line.rentalType = ev.target.value || "new_rental";
     }
 
-    async onLineRentalPeriodChange(line, ev) {
+    onLineRentalPeriodChange(line, ev) {
         line.rentalPeriodId = ev.target.value ? parseInt(ev.target.value) : null;
         if (line.productId && line.rentalPeriodId) {
-            line.priceUnit = await this.computePriceUnit(line.productId, line.rentalPeriodId);
+            line.priceUnit = this._computePriceUnit(
+                line.productId,
+                line.rentalPeriodId
+            );
         }
     }
 
@@ -1092,26 +902,22 @@ export class RentalDashboard extends Component {
         line.priceUnit = parseFloat(ev.target.value) || 0;
     }
 
-    async computePriceUnit(serviceProductId, periodId) {
+    // ── Pricing (now synchronous — uses cached pricings from modalProducts) ──
+
+    _computePriceUnit(serviceProductId, periodId) {
         if (!serviceProductId || !periodId) return 0;
 
-        // Get base price per period from product.rental.pricing
-        const [pricing] = await this.orm.searchRead(
-            "product.rental.pricing",
-            [["product_id", "=", serviceProductId], ["period_id", "=", periodId]],
-            ["price"]
-        );
+        const product = this.state.modalProducts.find((p) => p.id === serviceProductId);
+        if (!product) return 0;
+
+        const pricing = product.pricings.find((p) => p.period_id === periodId);
         if (!pricing) return 0;
 
         const basePrice = pricing.price;
-        const period = this.state.rentalPeriods.find(p => p.id === periodId);
+        const period = this.state.rentalPeriods.find((p) => p.id === periodId);
         if (!period) return basePrice;
 
-        // Match sale_rental _compute_price_unit:
-        // duration = diff_hours / hours_per_unit
-        // number_of_days = diff_hours / 24
-        // price_unit = (base_price * duration) / number_of_days
-        const diffHours = this.getDiffHours();
+        const diffHours = this._getDiffHours();
         if (diffHours <= 0) return basePrice;
 
         const duration = diffHours / period.hours_per_unit;
@@ -1119,274 +925,201 @@ export class RentalDashboard extends Component {
         return (basePrice * duration) / numberOfDays;
     }
 
-    getDiffHours() {
+    _getDiffHours() {
         if (!this.state.modalData.startDate || !this.state.modalData.endDate) return 0;
-        const from = new Date(this.state.modalData.startDate + 'T00:00:00');
-        const to = new Date(this.state.modalData.endDate + 'T00:00:00');
+        const from = new Date(this.state.modalData.startDate + "T00:00:00");
+        const to = new Date(this.state.modalData.endDate + "T00:00:00");
         return Math.max(0, (to - from) / (1000 * 60 * 60));
     }
 
-    getNumberOfDays() {
-        const diffHours = this.getDiffHours();
+    _getNumberOfDays() {
+        const diffHours = this._getDiffHours();
         return diffHours > 0 ? diffHours / 24 : 1;
     }
 
     getLineSubtotal(line) {
-        // Match sale_rental: price_subtotal = price_unit * product_uom_qty
-        // where product_uom_qty = rental_qty * number_of_days
-        return line.priceUnit * line.rentalQty * this.getNumberOfDays();
-    }
-
-    getLineTotal(line) {
-        return this.getLineSubtotal(line);
+        return line.priceUnit * line.rentalQty * this._getNumberOfDays();
     }
 
     get modalSubtotal() {
-        return this.state.modalData.lines.reduce((sum, line) => sum + this.getLineSubtotal(line), 0);
-    }
-
-    get modalTotal() {
-        return this.modalSubtotal;
+        return this.state.modalData.lines.reduce(
+            (sum, line) => sum + this.getLineSubtotal(line),
+            0
+        );
     }
 
     addLine() {
-        this.state.modalData.lines.push(this.createEmptyLine());
+        this.state.modalData.lines.push(this._createEmptyLine());
     }
 
     removeLine(lineId) {
-        const index = this.state.modalData.lines.findIndex(l => l.id === lineId);
+        const index = this.state.modalData.lines.findIndex((l) => l.id === lineId);
         if (index > -1 && this.state.modalData.lines.length > 1) {
             this.state.modalData.lines.splice(index, 1);
         }
     }
 
     formatCurrency(amount) {
-        return '$' + amount.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+        return "$" + amount.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ",");
     }
 
-    async checkAvailability(validLines, locationId, startDate, endDate) {
-        const rentalInIds = [locationId];
-
-        // Get stock at rental_in location
-        const quants = await this.orm.searchRead(
-            "stock.quant",
-            [["location_id", "in", rentalInIds], ["quantity", ">", 0]],
-            ["product_id", "quantity"]
-        );
-        const rentalInQtyMap = {};
-        quants.forEach(q => {
-            const pid = q.product_id[0];
-            rentalInQtyMap[pid] = (rentalInQtyMap[pid] || 0) + q.quantity;
-        });
-
-        // Get committed rentals overlapping with the date range
-        const rentalDomain = [
-            ["state", "=", "ordered"],
-            ["out_picking_id.location_id", "in", rentalInIds],
-            ["start_datetime", "<=", endDate + " 00:00:00"],
-            ["end_datetime", ">=", startDate + " 00:00:00"],
-        ];
-        // Exclude current order when editing
-        if (this.state.modalMode === 'edit' && this.state.editingOrderId) {
-            rentalDomain.push(["start_order_id", "!=", this.state.editingOrderId]);
-        }
-        const rentals = await this.orm.searchRead(
-            "sale.rental",
-            rentalDomain,
-            ["rented_product_id", "rental_qty"]
-        );
-        const committedQtyMap = {};
-        rentals.forEach(r => {
-            const pid = r.rented_product_id[0];
-            committedQtyMap[pid] = (committedQtyMap[pid] || 0) + r.rental_qty;
-        });
-
-        // Check each line: find physical product via modalProducts, then check availability
-        // Also aggregate qty per physical product across lines
-        const requestedQtyMap = {};
-        for (const line of validLines) {
-            const modalProduct = this.state.modalProducts.find(p => p.id === line.productId);
-            const physicalId = modalProduct ? modalProduct.physicalProductId : null;
-            if (physicalId) {
-                requestedQtyMap[physicalId] = (requestedQtyMap[physicalId] || 0) + line.rentalQty;
-            }
-        }
-
-        const errors = [];
-        for (const [physicalId, requestedQty] of Object.entries(requestedQtyMap)) {
-            const rentalInQty = rentalInQtyMap[physicalId] || 0;
-            const committed = committedQtyMap[physicalId] || 0;
-            const available = Math.max(0, rentalInQty - committed);
-            if (requestedQty > available) {
-                // Find product name from modal products
-                const product = this.state.modalProducts.find(p => p.physicalProductId === parseInt(physicalId));
-                const name = product ? product.name : 'Unknown';
-                errors.push(`${name}: requested ${requestedQty}, available ${available}`);
-            }
-        }
-
-        return errors;
-    }
+    // ── Save rental order ──
 
     async confirmRental() {
         const data = this.state.modalData;
 
-        // Validation
         if (!data.locationId) {
-            alert('Please select a location');
+            alert("Please select a location");
             return;
         }
         if (!data.customerId) {
-            alert('Please select a customer');
+            alert("Please select a customer");
             return;
         }
         if (!data.startDate || !data.endDate) {
-            alert('Please select start and end dates');
+            alert("Please select start and end dates");
             return;
         }
 
-        const validLines = data.lines.filter(l => l.productId && l.rentalQty > 0);
+        const validLines = data.lines.filter((l) => l.productId && l.rentalQty > 0);
         if (validLines.length === 0) {
-            alert('Please add at least one equipment with a rental service configured');
+            alert("Please add at least one equipment with a rental service configured");
             return;
         }
 
-        // Get warehouse from selected location
-        const loc = this.state.locations.find(l => l.id === data.locationId);
+        const loc = this.state.locations.find((l) => l.id === data.locationId);
         if (!loc) {
-            alert('Invalid location');
+            alert("Invalid location");
             return;
         }
 
-        // Check availability before saving
-        const availErrors = await this.checkAvailability(validLines, data.locationId, data.startDate, data.endDate);
+        // Server-side availability check (1 RPC replaces 2)
+        const availErrors = await this.orm.call(
+            "product.product",
+            "check_rental_availability",
+            [
+                data.locationId,
+                data.startDate,
+                data.endDate,
+                validLines.map((l) => ({
+                    product_id: l.productId,
+                    rental_qty: l.rentalQty,
+                })),
+                this.state.modalMode === "edit" ? this.state.editingOrderId : null,
+            ]
+        );
         if (availErrors.length > 0) {
-            alert('Insufficient availability:\n\n' + availErrors.join('\n'));
+            alert("Insufficient availability:\n\n" + availErrors.join("\n"));
             return;
         }
 
-        const startDatetime = data.startDate + ' 00:00:00';
-        const endDatetime = data.endDate + ' 00:00:00';
-        const diffHours = this.getDiffHours();
-        const numberOfDays = diffHours / 24;
+        const startDatetime = data.startDate + " 00:00:00";
+        const endDatetime = data.endDate + " 00:00:00";
+        const numberOfDays = this._getNumberOfDays();
+
+        const lineVals = validLines.map((line) => ({
+            product_id: line.productId,
+            rental_type: line.rentalType,
+            rental_qty: line.rentalQty,
+            rental_period_id: line.rentalPeriodId,
+            start_datetime: startDatetime,
+            end_datetime: endDatetime,
+            product_uom_qty: line.rentalQty * numberOfDays,
+            price_unit: line.priceUnit,
+        }));
+
+        const orderVals = {
+            partner_id: data.customerId,
+            warehouse_id: loc.warehouse_id,
+            lines: lineVals,
+        };
 
         try {
-            if (this.state.modalMode === 'edit' && this.state.editingOrderId) {
-                // Update existing SO (only if draft)
-                await this.orm.write("sale.order", [this.state.editingOrderId], {
-                    partner_id: data.customerId,
-                    warehouse_id: loc.warehouse_id,
-                });
-
-                // Delete old rental lines and create new ones
-                const oldLines = await this.orm.searchRead(
-                    "sale.order.line",
-                    [["order_id", "=", this.state.editingOrderId], ["rental", "=", true]],
-                    ["id"]
-                );
-                if (oldLines.length > 0) {
-                    await this.orm.unlink("sale.order.line", oldLines.map(l => l.id));
-                }
-
-                for (const line of validLines) {
-                    await this.orm.create("sale.order.line", [{
-                        order_id: this.state.editingOrderId,
-                        product_id: line.productId,
-                        rental: true,
-                        rental_type: line.rentalType,
-                        rental_qty: line.rentalQty,
-                        rental_period_id: line.rentalPeriodId,
-                        start_datetime: startDatetime,
-                        end_datetime: endDatetime,
-                        product_uom_qty: line.rentalQty * numberOfDays,
-                        price_unit: line.priceUnit,
-                    }]);
-                }
-
+            if (this.state.modalMode === "edit" && this.state.editingOrderId) {
+                // Single RPC replaces N+3 calls
+                await this.orm.call("sale.order.line", "update_rental_order", [
+                    this.state.editingOrderId,
+                    orderVals,
+                ]);
             } else {
-                // Create new sale order
-                const orderId = await this.orm.create("sale.order", [{
-                    partner_id: data.customerId,
-                    warehouse_id: loc.warehouse_id,
-                }]);
+                // Single RPC replaces N+1 calls
+                const orderId = await this.orm.call(
+                    "sale.order.line",
+                    "create_rental_order",
+                    [orderVals]
+                );
                 this.state.createdOrderId = orderId;
-
-                // Create SO lines
-                for (const line of validLines) {
-                    await this.orm.create("sale.order.line", [{
-                        order_id: orderId,
-                        product_id: line.productId,
-                        rental: true,
-                        rental_type: line.rentalType,
-                        rental_qty: line.rentalQty,
-                        rental_period_id: line.rentalPeriodId,
-                        start_datetime: startDatetime,
-                        end_datetime: endDatetime,
-                        product_uom_qty: line.rentalQty * numberOfDays,
-                        price_unit: line.priceUnit,
-                    }]);
-                }
-
             }
 
-            // Refresh calendar and products
-            this.state.calendarKey++;
+            this._refreshCalendar();
             await this.loadProducts();
 
-            if (this.state.modalMode === 'create' && this.state.createdOrderId) {
-                // Show success state with action buttons
-                this.state.modalMode = 'created';
+            if (this.state.modalMode === "create" && this.state.createdOrderId) {
+                this.state.modalMode = "created";
             } else {
                 this.state.showModal = false;
             }
-
         } catch (error) {
-            console.error('Error saving rental:', error);
-            alert('Error saving rental. Please try again.');
+            console.error("Error saving rental:", error);
+            alert("Error saving rental. Please try again.");
         }
     }
 
+    // ── Display helpers ──
+
     getAvailabilityClass(product) {
-        if (product.availability_status === 'available') return 'bg-success';
-        if (product.availability_status === 'low') return 'bg-warning';
-        return 'bg-danger';
+        if (product.availability_status === "available") return "bg-success";
+        if (product.availability_status === "low") return "bg-warning";
+        return "bg-danger";
     }
 
     getAvailabilityText(product) {
         const available = product.qty_available || 0;
         const total = product.qty_total;
         if (total !== undefined && total !== available) {
-            if (available > 0) return `${available} of ${total} available`;
-            return `0 of ${total} available`;
+            return available > 0
+                ? `${available} of ${total} available`
+                : `0 of ${total} available`;
         }
-        if (available > 0) return `${available} available`;
-        return 'Unavailable';
+        return available > 0 ? `${available} available` : "Unavailable";
     }
 
     getProductColorStyle(product) {
-        const colors = ['#CCCCCC', '#F06050', '#F4A460', '#F7CD1F', '#6CC1ED', '#814968', '#EB7E7F', '#2C8397', '#475577', '#D6145F', '#30C381', '#9365B8'];
-        const color = colors[product.rental_color || 0];
-        return `background-color: ${color};`;
+        const colors = [
+            "#CCCCCC",
+            "#F06050",
+            "#F4A460",
+            "#F7CD1F",
+            "#6CC1ED",
+            "#814968",
+            "#EB7E7F",
+            "#2C8397",
+            "#475577",
+            "#D6145F",
+            "#30C381",
+            "#9365B8",
+        ];
+        return `background-color: ${colors[product.rental_color || 0]};`;
     }
 
     getStatusBadgeClass(state) {
         const classes = {
-            'draft': 'bg-secondary',
-            'sent': 'bg-info',
-            'sale': 'bg-primary',
-            'done': 'bg-success',
-            'cancel': 'bg-danger',
+            draft: "bg-secondary",
+            sent: "bg-info",
+            sale: "bg-primary",
+            done: "bg-success",
+            cancel: "bg-danger",
         };
-        return classes[state] || 'bg-secondary';
+        return classes[state] || "bg-secondary";
     }
 
     getStatusLabel(state) {
         const labels = {
-            'draft': 'Quotation',
-            'sent': 'Sent',
-            'sale': 'Confirmed',
-            'done': 'Done',
-            'cancel': 'Cancelled',
+            draft: "Quotation",
+            sent: "Sent",
+            sale: "Confirmed",
+            done: "Done",
+            cancel: "Cancelled",
         };
         return labels[state] || state;
     }
@@ -1396,7 +1129,10 @@ export class RentalDashboard extends Component {
             type: "ir.actions.act_window",
             name: "Rental Calendar",
             res_model: "sale.order.line",
-            views: [[false, "calendar"], [false, "form"]],
+            views: [
+                [false, "calendar"],
+                [false, "form"],
+            ],
             target: "current",
             domain: [["rental", "=", true]],
         });

--- a/rental_dashboard/static/src/scss/rental_dashboard.scss
+++ b/rental_dashboard/static/src/scss/rental_dashboard.scss
@@ -42,6 +42,71 @@
             .date-picker-dropdown {
                 left: 0;
                 right: 0;
+
+                .rdp-grid {
+                    display: grid;
+                    grid-template-columns: repeat(7, 1fr);
+                    gap: 1px;
+                }
+
+                .rdp-cell {
+                    aspect-ratio: 1;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    font-size: 0.82rem;
+                    user-select: none;
+                    border-radius: 50%;
+
+                    &.rdp-weekday {
+                        color: #6c757d;
+                        font-weight: 600;
+                        font-size: 0.75rem;
+                    }
+
+                    &.rdp-day {
+                        cursor: pointer;
+
+                        &:hover:not(.rdp-in-range):not(.rdp-hover-range) {
+                            background-color: #e9ecef;
+                        }
+                    }
+
+                    &.rdp-in-range {
+                        background-color: #0d6efd;
+                        color: white;
+                        border-radius: 0;
+                    }
+
+                    &.rdp-in-range.rdp-range-start {
+                        border-radius: 50% 0 0 50%;
+                    }
+
+                    &.rdp-in-range.rdp-range-end {
+                        border-radius: 0 50% 50% 0;
+                    }
+
+                    &.rdp-in-range.rdp-range-start.rdp-range-end {
+                        border-radius: 50%;
+                    }
+
+                    &.rdp-hover-range {
+                        background-color: rgba(13, 110, 253, 0.15);
+                        border-radius: 0;
+                    }
+
+                    &.rdp-hover-range.rdp-hover-start {
+                        border-radius: 50% 0 0 50%;
+                    }
+
+                    &.rdp-hover-range.rdp-hover-end {
+                        border-radius: 0 50% 50% 0;
+                    }
+
+                    &.rdp-hover-range.rdp-hover-start.rdp-hover-end {
+                        border-radius: 50%;
+                    }
+                }
             }
         }
     }

--- a/rental_dashboard/static/src/scss/rental_dashboard.scss
+++ b/rental_dashboard/static/src/scss/rental_dashboard.scss
@@ -228,7 +228,7 @@
 
     // Arrow pointing down
     &::after {
-        content: '';
+        content: "";
         position: absolute;
         left: 50%;
         bottom: -8px;

--- a/rental_dashboard/static/src/scss/rental_dashboard.scss
+++ b/rental_dashboard/static/src/scss/rental_dashboard.scss
@@ -1,0 +1,240 @@
+.rental-dashboard {
+    height: calc(100vh - 50px);
+    background-color: #f8f9fa;
+
+    .rental-sidebar {
+        .product-card {
+            cursor: pointer;
+            transition: all 0.2s ease;
+
+            &:hover {
+                background-color: #e9ecef !important;
+                border-color: #dee2e6 !important;
+            }
+
+            &.product-unavailable {
+                opacity: 0.6;
+                cursor: not-allowed;
+
+                &:hover {
+                    background-color: #f8f9fa !important;
+                }
+            }
+        }
+
+        .product-color-dot {
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            display: inline-block;
+            flex-shrink: 0;
+        }
+
+        .date-range-picker {
+            .form-control {
+                cursor: pointer;
+
+                &:hover {
+                    border-color: #86b7fe;
+                }
+            }
+
+            .date-picker-dropdown {
+                left: 0;
+                right: 0;
+            }
+        }
+    }
+
+    .rental-calendar {
+        .o_view_controller {
+            height: 100%;
+        }
+
+        .o_calendar_view {
+            height: 100%;
+        }
+
+        // Hide the search panel in embedded calendar
+        .o_search_panel {
+            display: none;
+        }
+
+        // Gray out calendar days outside selected date range
+        .date-outside-range {
+            background-color: #d3d3d3 !important;
+
+            .fc-daygrid-day-top,
+            .fc-daygrid-day-number {
+                opacity: 0.4;
+                color: #888 !important;
+            }
+
+            .fc-daygrid-day-events {
+                opacity: 0.3;
+            }
+        }
+
+        // Highlight days inside selected date range
+        .date-in-range {
+            background-color: #fff !important;
+        }
+        // this for hidden the right side of calendar
+        // Hide the calendar sidebar (mini calendar + filters)
+        .o_calendar_sidebar {
+            display: none !important;
+        }
+
+        // Make the main calendar take full width
+        .o_calendar_widget {
+            width: 100% !important;
+            flex: 1 !important;
+        }
+
+        // Hide control panel elements we don't need
+        .o_control_panel {
+            .o_cp_searchview,
+            .o_searchview {
+                display: none !important;
+            }
+        }
+
+        // Style the calendar header (month/year + navigation)
+        .fc-header-toolbar {
+            padding: 12px 16px;
+            margin-bottom: 0 !important;
+
+            .fc-toolbar-title {
+                font-size: 1.5rem;
+                font-weight: 600;
+            }
+
+            // Style navigation buttons
+            .fc-button {
+                background-color: transparent;
+                border: 1px solid #dee2e6;
+                color: #495057;
+                padding: 4px 12px;
+
+                &:hover {
+                    background-color: #f8f9fa;
+                }
+
+                &:focus {
+                    box-shadow: none;
+                }
+            }
+
+            .fc-button-group {
+                .fc-button {
+                    border-radius: 0;
+
+                    &:first-child {
+                        border-radius: 4px 0 0 4px;
+                    }
+
+                    &:last-child {
+                        border-radius: 0 4px 4px 0;
+                    }
+                }
+            }
+        }
+
+        // Hide view switcher buttons (day/week/month) if not needed
+        .fc-header-toolbar .fc-button-group:last-child {
+            // display: none; // Uncomment to hide view switcher
+        }
+    }
+}
+
+// Bootstrap 5 utility class for Odoo 16
+.bg-primary-subtle {
+    background-color: rgba(13, 110, 253, 0.1) !important;
+}
+
+// Modal styles
+.rental-modal-backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 1050;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.rental-modal {
+    background-color: white;
+    border-radius: 12px;
+    padding: 24px;
+    width: 90%;
+    max-width: 900px;
+    max-height: 90vh;
+    overflow-y: auto;
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
+
+    .customer-option {
+        &:hover {
+            background-color: #f8f9fa;
+        }
+    }
+}
+
+// Cursor pointer utility
+.cursor-pointer {
+    cursor: pointer;
+}
+
+// Event hover tooltip
+.rental-event-tooltip {
+    position: fixed;
+    z-index: 1060;
+    transform: translate(-50%, -100%);
+    pointer-events: none;
+
+    .tooltip-content {
+        background-color: white;
+        border-radius: 8px;
+        padding: 16px;
+        min-width: 220px;
+        max-width: 300px;
+        box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+        border: 1px solid #e9ecef;
+
+        .tooltip-title {
+            font-size: 1.1rem;
+            color: #212529;
+            line-height: 1.3;
+        }
+
+        .tooltip-dates {
+            font-size: 0.95rem;
+            color: #495057;
+        }
+
+        .tooltip-info {
+            font-size: 0.9rem;
+            color: #6c757d;
+
+            i {
+                width: 16px;
+                text-align: center;
+            }
+        }
+    }
+
+    // Arrow pointing down
+    &::after {
+        content: '';
+        position: absolute;
+        left: 50%;
+        bottom: -8px;
+        transform: translateX(-50%);
+        border-left: 8px solid transparent;
+        border-right: 8px solid transparent;
+        border-top: 8px solid white;
+    }
+}

--- a/rental_dashboard/static/src/xml/rental_dashboard.xml
+++ b/rental_dashboard/static/src/xml/rental_dashboard.xml
@@ -32,17 +32,49 @@
                 <!-- Location Filter -->
                 <div class="mb-3">
                     <label class="form-label small text-muted">Location</label>
-                    <select class="form-select" t-on-change="onLocationChange">
-                        <option value="">Select a location</option>
-                        <t t-foreach="state.locations" t-as="loc" t-key="loc.id">
-                            <option
-                                t-att-value="loc.id"
-                                t-att-selected="state.selectedLocation === loc.id"
+                    <div class="position-relative">
+                        <input
+                            type="text"
+                            class="form-control"
+                            placeholder="Search location..."
+                            t-att-value="state.locationSearch"
+                            t-on-input="onLocationSearchInput"
+                            t-on-focus="onLocationSearchFocus"
+                            t-on-blur="onLocationSearchBlur"
+                        />
+                        <i
+                            class="fa fa-search position-absolute"
+                            style="right: 12px; top: 50%; transform: translateY(-50%); color: #6c757d;"
+                        />
+                        <div
+                            t-if="state.locationDropdownOpen and state.locationResults.length > 0"
+                            class="position-absolute bg-white border rounded shadow-sm w-100 mt-1"
+                            style="z-index: 1001; max-height: 220px; overflow-y: auto;"
+                        >
+                            <t
+                                t-foreach="state.locationResults"
+                                t-as="loc"
+                                t-key="loc.id"
                             >
-                                <t t-esc="loc.name" />
-                            </option>
-                        </t>
-                    </select>
+                                <div
+                                    class="p-2 cursor-pointer customer-option"
+                                    t-on-click="() => this.selectLocation(loc)"
+                                >
+                                    <t t-esc="loc.name" />
+                                </div>
+                            </t>
+                            <div
+                                t-if="state.locationHasMore"
+                                class="border-top text-center p-2"
+                            >
+                                <a
+                                    href="#"
+                                    class="small text-primary"
+                                    t-on-click.prevent="loadMoreLocations"
+                                >Search more...</a>
+                            </div>
+                        </div>
+                    </div>
                 </div>
 
                 <!-- Date Range Filter -->
@@ -53,48 +85,80 @@
                             class="form-control d-flex align-items-center justify-content-between cursor-pointer"
                             t-on-click="toggleDatePicker"
                         >
-                            <span t-if="state.dateFrom and state.dateTo">
+                            <span t-if="state.dateFrom or state.dateTo" class="small">
                                 <t t-esc="formatDateRange()" />
                             </span>
                             <span t-else="" class="text-muted">Select dates</span>
                             <i class="fa fa-calendar" />
                         </div>
-                        <!-- Date picker dropdown -->
+                        <!-- Calendar dropdown -->
                         <div
                             t-if="state.showDatePicker"
                             class="date-picker-dropdown position-absolute bg-white border rounded shadow-sm p-3 mt-1"
                             style="z-index: 1000; width: 100%;"
                         >
-                            <div class="mb-2">
-                                <label class="form-label small">From</label>
-                                <input
-                                    type="date"
-                                    class="form-control"
-                                    t-att-value="state.dateFrom"
-                                    t-on-change="onDateFromChange"
-                                />
+                            <!-- Month navigation -->
+                            <div
+                                class="d-flex justify-content-between align-items-center mb-2"
+                            >
+                                <button
+                                    class="btn btn-sm btn-link text-dark p-1"
+                                    t-on-click.stop="prevMonth"
+                                ><i class="fa fa-chevron-left" /></button>
+                                <span class="fw-bold small">
+                                    <t t-esc="getCalendarMonthLabel()" />
+                                </span>
+                                <button
+                                    class="btn btn-sm btn-link text-dark p-1"
+                                    t-on-click.stop="nextMonth"
+                                ><i class="fa fa-chevron-right" /></button>
                             </div>
-                            <div class="mb-2">
-                                <label class="form-label small">To</label>
-                                <input
-                                    type="date"
-                                    class="form-control"
-                                    t-att-value="state.dateTo"
-                                    t-on-change="onDateToChange"
-                                />
+                            <!-- Day grid -->
+                            <div class="rdp-grid">
+                                <t
+                                    t-foreach="['Su','Mo','Tu','We','Th','Fr','Sa']"
+                                    t-as="wday"
+                                    t-key="wday"
+                                >
+                                    <div class="rdp-cell rdp-weekday"><t
+                                            t-esc="wday"
+                                        /></div>
+                                </t>
+                                <t
+                                    t-foreach="getCalendarDays()"
+                                    t-as="cell"
+                                    t-key="cell.key"
+                                >
+                                    <div
+                                        t-att-class="getCalendarDayClass(cell)"
+                                        t-on-click.stop="() => this.onCalendarDayClick(cell)"
+                                        t-on-mouseenter="() => this.onCalendarDayHover(cell)"
+                                    >
+                                        <span t-if="cell.day"><t
+                                                t-esc="cell.day"
+                                            /></span>
+                                    </div>
+                                </t>
                             </div>
-                            <div class="d-flex justify-content-end gap-2">
+                            <!-- Clear -->
+                            <div class="d-flex justify-content-end mt-2">
                                 <button
                                     class="btn btn-sm btn-outline-secondary"
-                                    t-on-click="clearDateFilter"
+                                    t-on-click.stop="clearDateFilter"
                                 >Clear</button>
-                                <button
-                                    class="btn btn-sm btn-primary"
-                                    t-on-click="applyDateFilter"
-                                >Apply</button>
                             </div>
                         </div>
                     </div>
+                </div>
+
+                <!-- Apply Search Button -->
+                <div class="mb-3">
+                    <button
+                        t-att-class="'btn w-100 ' + (state.filtersChanged ? 'btn-primary' : 'd-none')"
+                        t-on-click="applySearch"
+                    >
+                        <i class="fa fa-search me-2" />Apply search
+                    </button>
                 </div>
 
                 <!-- Show Available Only -->
@@ -212,8 +276,6 @@
             </div>
         </div>
 
-        <!-- Tooltip is managed by plain DOM in JS to avoid OWL re-renders -->
-
         <!-- Create/Edit Rental Modal -->
         <div
             t-if="state.showModal"
@@ -263,7 +325,8 @@
                         </h4>
                         <t t-if="state.modalMode === 'edit' and state.modalData.state">
                             <span
-                                    t-att-class="'badge ' + getStatusBadgeClass(state.modalData.state)"
+                                    style="padding: 4px 10px; border-radius: 999px; font-size: 0.75rem; font-weight: 600; display: inline-block;"
+                                    t-att-style="getStatusBadgeStyle(state.modalData.state)"
                                 >
                                 <t t-esc="getStatusLabel(state.modalData.state)" />
                             </span>
@@ -279,17 +342,48 @@
                     <!-- Location (Warehouse) -->
                     <div class="col-md-3">
                         <label class="form-label small text-muted">Warehouse</label>
-                        <select class="form-select" t-on-change="onModalLocationChange">
-                            <option value="">Select warehouse</option>
-                            <t t-foreach="state.locations" t-as="loc" t-key="loc.id">
-                                <option
-                                        t-att-value="loc.id"
-                                        t-att-selected="state.modalData.locationId === loc.id"
+                        <div class="position-relative">
+                            <input
+                                    type="text"
+                                    class="form-control"
+                                    placeholder="Search warehouse..."
+                                    t-att-value="state.modalData.locationSearch"
+                                    t-on-input="onModalLocationSearchInput"
+                                    t-on-focus="onModalLocationSearchFocus"
+                                />
+                            <i
+                                    class="fa fa-search position-absolute"
+                                    style="right: 12px; top: 50%; transform: translateY(-50%); color: #6c757d;"
+                                />
+                            <div
+                                    t-if="state.modalLocationResults.length > 0"
+                                    class="position-absolute bg-white border rounded shadow-sm w-100 mt-1"
+                                    style="z-index: 1001; max-height: 220px; overflow-y: auto;"
+                                >
+                                <t
+                                        t-foreach="state.modalLocationResults"
+                                        t-as="loc"
+                                        t-key="loc.id"
                                     >
-                                    <t t-esc="loc.name" />
-                                </option>
-                            </t>
-                        </select>
+                                    <div
+                                            class="p-2 cursor-pointer customer-option"
+                                            t-on-click="() => this.selectModalLocation(loc)"
+                                        >
+                                        <t t-esc="loc.name" />
+                                    </div>
+                                </t>
+                                <div
+                                        t-if="state.modalLocationHasMore"
+                                        class="border-top text-center p-2"
+                                    >
+                                    <a
+                                            href="#"
+                                            class="small text-primary"
+                                            t-on-click.prevent="loadMoreModalLocations"
+                                        >Search more...</a>
+                                </div>
+                            </div>
+                        </div>
                     </div>
 
                     <!-- Customer -->
@@ -302,6 +396,7 @@
                                     placeholder="Search customer..."
                                     t-att-value="state.modalData.customerSearch"
                                     t-on-input="onCustomerSearch"
+                                    t-on-focus="onCustomerSearchFocus"
                                 />
                             <i
                                     class="fa fa-search position-absolute"
@@ -310,7 +405,7 @@
                             <div
                                     t-if="state.customers.length > 0"
                                     class="position-absolute bg-white border rounded shadow-sm w-100 mt-1"
-                                    style="z-index: 1001; max-height: 200px; overflow-y: auto;"
+                                    style="z-index: 1001; max-height: 220px; overflow-y: auto;"
                                 >
                                 <t
                                         t-foreach="state.customers"
@@ -328,6 +423,16 @@
                                             ><t t-esc="customer.email" /></small>
                                     </div>
                                 </t>
+                                <div
+                                        t-if="state.customerHasMore"
+                                        class="border-top text-center p-2"
+                                    >
+                                    <a
+                                            href="#"
+                                            class="small text-primary"
+                                            t-on-click.prevent="loadMoreCustomers"
+                                        >Search more...</a>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -374,24 +479,44 @@
                     <div class="row mb-2 align-items-center">
                         <!-- Equipment (rental service product) -->
                         <div class="col-3">
-                            <select
-                                    class="form-select form-select-sm"
-                                    t-on-change="(ev) => this.onLineProductChange(line, ev)"
-                                >
-                                <option value="">Select equipment</option>
-                                <t
-                                        t-foreach="state.modalProducts"
-                                        t-as="product"
-                                        t-key="product.id"
+                            <div class="position-relative">
+                                <input
+                                        type="text"
+                                        class="form-control form-control-sm"
+                                        placeholder="Search equipment..."
+                                        t-att-value="line.productSearch"
+                                        t-on-input="(ev) => this.onLineProductSearchInput(line, ev)"
+                                        t-on-focus="() => this.onLineProductSearchFocus(line)"
+                                    />
+                                <div
+                                        t-if="line.productResults.length > 0"
+                                        class="position-absolute bg-white border rounded shadow-sm w-100 mt-1"
+                                        style="z-index: 1001; max-height: 220px; overflow-y: auto;"
                                     >
-                                    <option
-                                            t-att-value="product.id"
-                                            t-att-selected="line.productId === product.id"
+                                    <t
+                                            t-foreach="line.productResults"
+                                            t-as="product"
+                                            t-key="product.id"
                                         >
-                                        <t t-esc="product.name" />
-                                    </option>
-                                </t>
-                            </select>
+                                        <div
+                                                class="p-2 cursor-pointer customer-option small"
+                                                t-on-click="() => this.selectLineProduct(line, product)"
+                                            >
+                                            <t t-esc="product.name" />
+                                        </div>
+                                    </t>
+                                    <div
+                                            t-if="line.productHasMore"
+                                            class="border-top text-center p-2"
+                                        >
+                                        <a
+                                                href="#"
+                                                class="small text-primary"
+                                                t-on-click.prevent="() => this.loadMoreLineProducts(line)"
+                                            >Search more...</a>
+                                    </div>
+                                </div>
+                            </div>
                             <small
                                     class="text-success d-block"
                                     t-if="line.available > 0"
@@ -400,7 +525,10 @@
                                         t-esc="line.available"
                                     /> avail.
                             </small>
-                            <small class="text-danger d-block" t-else="">
+                            <small
+                                    class="text-danger d-block"
+                                    t-if="line.productId and line.available === 0"
+                                >
                                 <i class="fa fa-times" /> Unavailable
                             </small>
                         </div>
@@ -428,7 +556,6 @@
                                     class="form-select form-select-sm"
                                     t-on-change="(ev) => this.onLineRentalPeriodChange(line, ev)"
                                 >
-<!--                                <option value="" disabled="1">Period</option>-->
                                 <t
                                         t-foreach="getLineAvailablePeriods(line)"
                                         t-as="period"
@@ -486,6 +613,49 @@
                             </button>
                         </div>
                     </div>
+
+                    <!-- Extension rental picker (only for rental_extension type) -->
+                    <div t-if="line.rentalType === 'rental_extension'" class="row mb-2">
+                        <div class="col-1 text-end small text-muted pt-1">Extends</div>
+                        <div class="col-11 position-relative">
+                            <input
+                                    type="text"
+                                    class="form-control form-control-sm"
+                                    placeholder="Search rental to extend..."
+                                    t-att-value="line.extensionRentalSearch"
+                                    t-on-input="(ev) => this.onLineExtensionSearchInput(line, ev)"
+                                    t-on-focus="() => this.onLineExtensionSearchFocus(line)"
+                                />
+                            <div
+                                    t-if="line.extensionRentalResults.length > 0"
+                                    class="position-absolute bg-white border rounded shadow-sm mt-1"
+                                    style="z-index: 1001; max-height: 220px; overflow-y: auto; left: 12px; right: 0;"
+                                >
+                                <t
+                                        t-foreach="line.extensionRentalResults"
+                                        t-as="rental"
+                                        t-key="rental.id"
+                                    >
+                                    <div
+                                            class="p-2 cursor-pointer customer-option small"
+                                            t-on-click="() => this.selectLineExtension(line, rental)"
+                                        >
+                                        <t t-esc="rental.name" />
+                                    </div>
+                                </t>
+                                <div
+                                        t-if="line.extensionRentalHasMore"
+                                        class="border-top text-center p-2"
+                                    >
+                                    <a
+                                            href="#"
+                                            class="small text-primary"
+                                            t-on-click.prevent="() => this.loadMoreLineExtensions(line)"
+                                        >Search more...</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </t>
 
                 <!-- Add Line Button -->
@@ -515,9 +685,8 @@
                             <i class="fa fa-external-link me-2" />View Order
                         </button>
                         <button
-                                class="btn btn-success px-3"
+                                t-att-class="'btn btn-success px-3' + (state.modalData.state !== 'draft' ? ' d-none' : '')"
                                 t-on-click="confirmEditingOrder"
-                                t-att-disabled="state.modalData.state !== 'draft'"
                             >
                             <i class="fa fa-check me-2" />Confirm Order
                         </button>
@@ -528,7 +697,10 @@
                                 class="btn btn-outline-secondary px-4"
                                 t-on-click="closeModal"
                             >Cancel</button>
-                        <button class="btn btn-primary px-4" t-on-click="confirmRental">
+                        <button
+                                t-att-class="'btn btn-primary px-4' + (state.modalMode === 'edit' and state.modalData.state !== 'draft' ? ' d-none' : '')"
+                                t-on-click="confirmRental"
+                            >
                             <t t-if="state.modalMode === 'edit'">Save Changes</t>
                             <t t-else="">Create Order</t>
                         </button>

--- a/rental_dashboard/static/src/xml/rental_dashboard.xml
+++ b/rental_dashboard/static/src/xml/rental_dashboard.xml
@@ -1,22 +1,31 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
 
     <t t-name="rental_dashboard.RentalDashboard" owl="1">
         <div class="rental-dashboard d-flex h-100">
             <!-- Left Sidebar -->
-            <div class="rental-sidebar border-end bg-white p-3" style="width: 320px; min-width: 320px; overflow-y: auto;">
+            <div
+                class="rental-sidebar border-end bg-white p-3"
+                style="width: 320px; min-width: 320px; overflow-y: auto;"
+            >
                 <!-- Create Rental Button -->
-                <button class="btn w-50 mb-4"
-                        style="background-color: cornflowerblue; color: white;"
-                        t-on-click="openCreateModal">
-                    <i class="fa fa-plus me-2"/>Create rental
+                <button
+                    class="btn w-50 mb-4"
+                    style="background-color: cornflowerblue; color: white;"
+                    t-on-click="openCreateModal"
+                >
+                    <i class="fa fa-plus me-2" />Create rental
                 </button>
 
                 <!-- Search Section -->
                 <div class="d-flex justify-content-between align-items-center mb-3">
                     <h6 class="mb-0 fw-bold">Search rentals</h6>
-                    <a href="#" class="text-muted small" t-on-click.prevent="clearFilters">
-                        <i class="fa fa-times me-1"/>Clear filters
+                    <a
+                        href="#"
+                        class="text-muted small"
+                        t-on-click.prevent="clearFilters"
+                    >
+                        <i class="fa fa-times me-1" />Clear filters
                     </a>
                 </div>
 
@@ -26,8 +35,11 @@
                     <select class="form-select" t-on-change="onLocationChange">
                         <option value="">Select a location</option>
                         <t t-foreach="state.locations" t-as="loc" t-key="loc.id">
-                            <option t-att-value="loc.id" t-att-selected="state.selectedLocation === loc.id">
-                                <t t-esc="loc.name"/>
+                            <option
+                                t-att-value="loc.id"
+                                t-att-selected="state.selectedLocation === loc.id"
+                            >
+                                <t t-esc="loc.name" />
                             </option>
                         </t>
                     </select>
@@ -37,31 +49,49 @@
                 <div class="mb-3">
                     <label class="form-label small text-muted">Dates</label>
                     <div class="date-range-picker position-relative">
-                        <div class="form-control d-flex align-items-center justify-content-between cursor-pointer"
-                             t-on-click="toggleDatePicker">
+                        <div
+                            class="form-control d-flex align-items-center justify-content-between cursor-pointer"
+                            t-on-click="toggleDatePicker"
+                        >
                             <span t-if="state.dateFrom and state.dateTo">
-                                <t t-esc="formatDateRange()"/>
+                                <t t-esc="formatDateRange()" />
                             </span>
                             <span t-else="" class="text-muted">Select dates</span>
-                            <i class="fa fa-calendar"/>
+                            <i class="fa fa-calendar" />
                         </div>
                         <!-- Date picker dropdown -->
-                        <div t-if="state.showDatePicker" class="date-picker-dropdown position-absolute bg-white border rounded shadow-sm p-3 mt-1" style="z-index: 1000; width: 100%;">
+                        <div
+                            t-if="state.showDatePicker"
+                            class="date-picker-dropdown position-absolute bg-white border rounded shadow-sm p-3 mt-1"
+                            style="z-index: 1000; width: 100%;"
+                        >
                             <div class="mb-2">
                                 <label class="form-label small">From</label>
-                                <input type="date" class="form-control"
-                                       t-att-value="state.dateFrom"
-                                       t-on-change="onDateFromChange"/>
+                                <input
+                                    type="date"
+                                    class="form-control"
+                                    t-att-value="state.dateFrom"
+                                    t-on-change="onDateFromChange"
+                                />
                             </div>
                             <div class="mb-2">
                                 <label class="form-label small">To</label>
-                                <input type="date" class="form-control"
-                                       t-att-value="state.dateTo"
-                                       t-on-change="onDateToChange"/>
+                                <input
+                                    type="date"
+                                    class="form-control"
+                                    t-att-value="state.dateTo"
+                                    t-on-change="onDateToChange"
+                                />
                             </div>
                             <div class="d-flex justify-content-end gap-2">
-                                <button class="btn btn-sm btn-outline-secondary" t-on-click="clearDateFilter">Clear</button>
-                                <button class="btn btn-sm btn-primary" t-on-click="applyDateFilter">Apply</button>
+                                <button
+                                    class="btn btn-sm btn-outline-secondary"
+                                    t-on-click="clearDateFilter"
+                                >Clear</button>
+                                <button
+                                    class="btn btn-sm btn-primary"
+                                    t-on-click="applyDateFilter"
+                                >Apply</button>
                             </div>
                         </div>
                     </div>
@@ -69,75 +99,112 @@
 
                 <!-- Show Available Only -->
                 <div class="form-check mb-4">
-                    <input type="checkbox" class="form-check-input" id="showAvailable"
-                           t-att-checked="state.showAvailableOnly"
-                           t-on-change="onShowAvailableChange"/>
-                    <label class="form-check-label" for="showAvailable">Show available only</label>
+                    <input
+                        type="checkbox"
+                        class="form-check-input"
+                        id="showAvailable"
+                        t-att-checked="state.showAvailableOnly"
+                        t-on-change="onShowAvailableChange"
+                    />
+                    <label
+                        class="form-check-label"
+                        for="showAvailable"
+                    >Show available only</label>
                 </div>
 
                 <!-- Products List -->
                 <div class="products-list">
                     <t t-foreach="filteredProducts" t-as="product" t-key="product.id">
-                        <div t-att-class="'product-card border rounded p-2 mb-2 ' +
+                        <div
+                            t-att-class="'product-card border rounded p-2 mb-2 ' +
                              (isProductSelected(product.id) ? 'border-primary bg-primary-subtle' : 'bg-light') +
                              (product.qty_available === 0 ? ' product-unavailable' : '')"
-                             t-on-click="() => product.qty_available > 0 &amp;&amp; this.onProductSelect(product.id)">
+                            t-on-click="() => product.qty_available > 0 &amp;&amp; this.onProductSelect(product.id)"
+                        >
                             <div class="d-flex align-items-start">
                                 <!-- Checkbox -->
-                                <input type="checkbox" class="form-check-input me-2 mt-1"
-                                       t-att-checked="isProductSelected(product.id)"
-                                       t-att-disabled="product.qty_available === 0"
-                                       t-on-click.stop="() => product.qty_available > 0 &amp;&amp; this.onProductSelect(product.id)"/>
+                                <input
+                                    type="checkbox"
+                                    class="form-check-input me-2 mt-1"
+                                    t-att-checked="isProductSelected(product.id)"
+                                    t-att-disabled="product.qty_available === 0"
+                                    t-on-click.stop="() => product.qty_available > 0 &amp;&amp; this.onProductSelect(product.id)"
+                                />
 
                                 <!-- Color dot -->
-                                <span class="product-color-dot me-2 mt-1" t-att-style="getProductColorStyle(product)"/>
+                                <span
+                                    class="product-color-dot me-2 mt-1"
+                                    t-att-style="getProductColorStyle(product)"
+                                />
 
                                 <div class="flex-grow-1">
                                     <!-- Availability Badge -->
-                                    <span t-att-class="'badge rounded-pill mt-1 float-end ' + getAvailabilityClass(product)">
-                                        <i class="fa fa-check me-1" t-if="product.qty_available > 0"/>
-                                        <i class="fa fa-times me-1" t-if="product.qty_available === 0"/>
-                                        <t t-esc="getAvailabilityText(product)"/>
+                                    <span
+                                        t-att-class="'badge rounded-pill mt-1 float-end ' + getAvailabilityClass(product)"
+                                    >
+                                        <i
+                                            class="fa fa-check me-1"
+                                            t-if="product.qty_available > 0"
+                                        />
+                                        <i
+                                            class="fa fa-times me-1"
+                                            t-if="product.qty_available === 0"
+                                        />
+                                        <t t-esc="getAvailabilityText(product)" />
                                     </span>
 
                                     <!-- Product Name -->
                                     <div class="fw-semibold">
-                                        <t t-esc="product.name"/>
+                                        <t t-esc="product.name" />
                                     </div>
 
                                     <!-- Stock: available / total -->
                                     <div class="mt-1 small text-muted">
-                                        <i class="fa fa-cubes me-1"/>
-                                        <t t-esc="product.qty_available"/> available
-                                        <span class="text-muted"> / <t t-esc="product.qty_total"/> total</span>
+                                        <i class="fa fa-cubes me-1" />
+                                        <t t-esc="product.qty_available" /> available
+                                        <span class="text-muted"> / <t
+                                                t-esc="product.qty_total"
+                                            /> total</span>
                                     </div>
                                 </div>
                             </div>
                         </div>
                     </t>
 
-                    <div t-if="filteredProducts.length === 0" class="text-muted text-center py-4">
+                    <div
+                        t-if="filteredProducts.length === 0"
+                        class="text-muted text-center py-4"
+                    >
                         No products found
                     </div>
                 </div>
 
                 <!-- Rent Button (shows when products are selected) -->
                 <div t-if="state.selectedProducts.length > 0" class="mt-3">
-                    <button class="btn btn-outline-dark w-100 py-2" t-on-click="openCreateModal">
+                    <button
+                        class="btn btn-outline-dark w-100 py-2"
+                        t-on-click="openCreateModal"
+                    >
                         Rent
                     </button>
                 </div>
             </div>
 
             <!-- Right Calendar Area - Embedded Calendar -->
-            <div class="rental-calendar flex-grow-1" style="overflow: hidden;" t-ref="calendarContainer">
+            <div
+                class="rental-calendar flex-grow-1"
+                style="overflow: hidden;"
+                t-ref="calendarContainer"
+            >
                 <t t-if="calendarProps">
-                    <View t-key="state.calendarKey" t-props="calendarProps"/>
+                    <View t-key="state.calendarKey" t-props="calendarProps" />
                 </t>
                 <t t-else="">
-                    <div class="d-flex align-items-center justify-content-center h-100 bg-light">
+                    <div
+                        class="d-flex align-items-center justify-content-center h-100 bg-light"
+                    >
                         <div class="text-center">
-                            <i class="fa fa-spinner fa-spin fa-3x text-muted mb-3"/>
+                            <i class="fa fa-spinner fa-spin fa-3x text-muted mb-3" />
                             <p class="text-muted">Loading calendar...</p>
                         </div>
                     </div>
@@ -148,26 +215,38 @@
         <!-- Tooltip is managed by plain DOM in JS to avoid OWL re-renders -->
 
         <!-- Create/Edit Rental Modal -->
-        <div t-if="state.showModal" class="rental-modal-backdrop" t-on-click="closeModal">
+        <div
+            t-if="state.showModal"
+            class="rental-modal-backdrop"
+            t-on-click="closeModal"
+        >
             <div class="rental-modal" t-on-click.stop="">
 
                 <!-- Created Success State -->
                 <t t-if="state.modalMode === 'created'">
                     <div class="text-center py-5">
-                        <i class="fa fa-check-circle text-success fa-4x mb-3"/>
+                        <i class="fa fa-check-circle text-success fa-4x mb-3" />
                         <h4 class="fw-bold mb-4">Rental Order Created</h4>
                         <div class="d-flex justify-content-center gap-3">
-                            <button class="btn btn-outline-primary px-4" t-on-click="openCreatedOrder">
-                                <i class="fa fa-external-link me-2"/>View Sale Order
+                            <button
+                                class="btn btn-outline-primary px-4"
+                                t-on-click="openCreatedOrder"
+                            >
+                                <i class="fa fa-external-link me-2" />View Sale Order
                             </button>
-                            <button class="btn btn-primary px-4" t-on-click="confirmCreatedOrder">
-                                <i class="fa fa-check me-2"/>Confirm Order
+                            <button
+                                class="btn btn-primary px-4"
+                                t-on-click="confirmCreatedOrder"
+                            >
+                                <i class="fa fa-check me-2" />Confirm Order
                             </button>
                         </div>
                         <div class="mt-4">
-                            <button class="btn btn-outline-secondary px-4 py-2 rounded-pill shadow-sm"
-                                    t-on-click="closeModal">
-                                <i class="fa fa-times me-2 text-danger"/>Close
+                            <button
+                                class="btn btn-outline-secondary px-4 py-2 rounded-pill shadow-sm"
+                                t-on-click="closeModal"
+                            >
+                                <i class="fa fa-times me-2 text-danger" />Close
                             </button>
                         </div>
                     </div>
@@ -183,13 +262,15 @@
                             <t t-else="">New Rental Order</t>
                         </h4>
                         <t t-if="state.modalMode === 'edit' and state.modalData.state">
-                            <span t-att-class="'badge ' + getStatusBadgeClass(state.modalData.state)">
-                                <t t-esc="getStatusLabel(state.modalData.state)"/>
+                            <span
+                                    t-att-class="'badge ' + getStatusBadgeClass(state.modalData.state)"
+                                >
+                                <t t-esc="getStatusLabel(state.modalData.state)" />
                             </span>
                         </t>
                     </div>
                     <button class="btn btn-link text-dark p-0" t-on-click="closeModal">
-                        <i class="fa fa-times fa-lg"/>
+                        <i class="fa fa-times fa-lg" />
                     </button>
                 </div>
 
@@ -201,8 +282,11 @@
                         <select class="form-select" t-on-change="onModalLocationChange">
                             <option value="">Select warehouse</option>
                             <t t-foreach="state.locations" t-as="loc" t-key="loc.id">
-                                <option t-att-value="loc.id" t-att-selected="state.modalData.locationId === loc.id">
-                                    <t t-esc="loc.name"/>
+                                <option
+                                        t-att-value="loc.id"
+                                        t-att-selected="state.modalData.locationId === loc.id"
+                                    >
+                                    <t t-esc="loc.name" />
                                 </option>
                             </t>
                         </select>
@@ -212,16 +296,36 @@
                     <div class="col-md-3">
                         <label class="form-label small text-muted">Customer</label>
                         <div class="position-relative">
-                            <input type="text" class="form-control"
-                                   placeholder="Search customer..."
-                                   t-att-value="state.modalData.customerSearch"
-                                   t-on-input="onCustomerSearch"/>
-                            <i class="fa fa-search position-absolute" style="right: 12px; top: 50%; transform: translateY(-50%); color: #6c757d;"/>
-                            <div t-if="state.customers.length > 0" class="position-absolute bg-white border rounded shadow-sm w-100 mt-1" style="z-index: 1001; max-height: 200px; overflow-y: auto;">
-                                <t t-foreach="state.customers" t-as="customer" t-key="customer.id">
-                                    <div class="p-2 cursor-pointer customer-option" t-on-click="() => this.selectCustomer(customer)">
-                                        <div><t t-esc="customer.name"/></div>
-                                        <small class="text-muted" t-if="customer.email"><t t-esc="customer.email"/></small>
+                            <input
+                                    type="text"
+                                    class="form-control"
+                                    placeholder="Search customer..."
+                                    t-att-value="state.modalData.customerSearch"
+                                    t-on-input="onCustomerSearch"
+                                />
+                            <i
+                                    class="fa fa-search position-absolute"
+                                    style="right: 12px; top: 50%; transform: translateY(-50%); color: #6c757d;"
+                                />
+                            <div
+                                    t-if="state.customers.length > 0"
+                                    class="position-absolute bg-white border rounded shadow-sm w-100 mt-1"
+                                    style="z-index: 1001; max-height: 200px; overflow-y: auto;"
+                                >
+                                <t
+                                        t-foreach="state.customers"
+                                        t-as="customer"
+                                        t-key="customer.id"
+                                    >
+                                    <div
+                                            class="p-2 cursor-pointer customer-option"
+                                            t-on-click="() => this.selectCustomer(customer)"
+                                        >
+                                        <div><t t-esc="customer.name" /></div>
+                                        <small
+                                                class="text-muted"
+                                                t-if="customer.email"
+                                            ><t t-esc="customer.email" /></small>
                                     </div>
                                 </t>
                             </div>
@@ -231,17 +335,23 @@
                     <!-- Start Date -->
                     <div class="col-md-3">
                         <label class="form-label small text-muted">Start date</label>
-                        <input type="date" class="form-control"
-                               t-att-value="state.modalData.startDate"
-                               t-on-change="onModalStartDateChange"/>
+                        <input
+                                type="date"
+                                class="form-control"
+                                t-att-value="state.modalData.startDate"
+                                t-on-change="onModalStartDateChange"
+                            />
                     </div>
 
                     <!-- End Date -->
                     <div class="col-md-3">
                         <label class="form-label small text-muted">End date</label>
-                        <input type="date" class="form-control"
-                               t-att-value="state.modalData.endDate"
-                               t-on-change="onModalEndDateChange"/>
+                        <input
+                                type="date"
+                                class="form-control"
+                                t-att-value="state.modalData.endDate"
+                                t-on-change="onModalEndDateChange"
+                            />
                     </div>
                 </div>
 
@@ -256,7 +366,7 @@
                     <div class="col-1">Qty</div>
                     <div class="col-2">Price/Unit</div>
                     <div class="col-1 text-end">Total</div>
-                    <div class="col-1"></div>
+                    <div class="col-1" />
                 </div>
 
                 <!-- Lines -->
@@ -264,39 +374,71 @@
                     <div class="row mb-2 align-items-center">
                         <!-- Equipment (rental service product) -->
                         <div class="col-3">
-                            <select class="form-select form-select-sm" t-on-change="(ev) => this.onLineProductChange(line, ev)">
+                            <select
+                                    class="form-select form-select-sm"
+                                    t-on-change="(ev) => this.onLineProductChange(line, ev)"
+                                >
                                 <option value="">Select equipment</option>
-                                <t t-foreach="state.modalProducts" t-as="product" t-key="product.id">
-                                    <option t-att-value="product.id" t-att-selected="line.productId === product.id">
-                                        <t t-esc="product.name"/>
+                                <t
+                                        t-foreach="state.modalProducts"
+                                        t-as="product"
+                                        t-key="product.id"
+                                    >
+                                    <option
+                                            t-att-value="product.id"
+                                            t-att-selected="line.productId === product.id"
+                                        >
+                                        <t t-esc="product.name" />
                                     </option>
                                 </t>
                             </select>
-                            <small class="text-success d-block" t-if="line.available > 0">
-                                <i class="fa fa-check"/> <t t-esc="line.available"/> avail.
+                            <small
+                                    class="text-success d-block"
+                                    t-if="line.available > 0"
+                                >
+                                <i class="fa fa-check" /> <t
+                                        t-esc="line.available"
+                                    /> avail.
                             </small>
                             <small class="text-danger d-block" t-else="">
-                                <i class="fa fa-times"/> Unavailable
+                                <i class="fa fa-times" /> Unavailable
                             </small>
                         </div>
 
                         <!-- Rental Type -->
                         <div class="col-2">
-                            <select class="form-select form-select-sm"
-                                    t-on-change="(ev) => this.onLineRentalTypeChange(line, ev)">
-                                <option value="new_rental" t-att-selected="line.rentalType === 'new_rental'">New Rental</option>
-                                <option value="rental_extension" t-att-selected="line.rentalType === 'rental_extension'">Extension</option>
+                            <select
+                                    class="form-select form-select-sm"
+                                    t-on-change="(ev) => this.onLineRentalTypeChange(line, ev)"
+                                >
+                                <option
+                                        value="new_rental"
+                                        t-att-selected="line.rentalType === 'new_rental'"
+                                    >New Rental</option>
+                                <option
+                                        value="rental_extension"
+                                        t-att-selected="line.rentalType === 'rental_extension'"
+                                    >Extension</option>
                             </select>
                         </div>
 
                         <!-- Rental Period -->
                         <div class="col-2">
-                            <select class="form-select form-select-sm"
-                                    t-on-change="(ev) => this.onLineRentalPeriodChange(line, ev)">
+                            <select
+                                    class="form-select form-select-sm"
+                                    t-on-change="(ev) => this.onLineRentalPeriodChange(line, ev)"
+                                >
 <!--                                <option value="" disabled="1">Period</option>-->
-                                <t t-foreach="getLineAvailablePeriods(line)" t-as="period" t-key="period.id">
-                                    <option t-att-value="period.id" t-att-selected="line.rentalPeriodId === period.id">
-                                        <t t-esc="period.name"/>
+                                <t
+                                        t-foreach="getLineAvailablePeriods(line)"
+                                        t-as="period"
+                                        t-key="period.id"
+                                    >
+                                    <option
+                                            t-att-value="period.id"
+                                            t-att-selected="line.rentalPeriodId === period.id"
+                                        >
+                                        <t t-esc="period.name" />
                                     </option>
                                 </t>
                             </select>
@@ -304,31 +446,43 @@
 
                         <!-- Rental Qty -->
                         <div class="col-1">
-                            <input type="number" class="form-control form-control-sm text-center" min="1" step="1"
-                                   t-att-value="line.rentalQty"
-                                   t-on-change="(ev) => this.onLineRentalQtyChange(line, ev)"/>
+                            <input
+                                    type="number"
+                                    class="form-control form-control-sm text-center"
+                                    min="1"
+                                    step="1"
+                                    t-att-value="line.rentalQty"
+                                    t-on-change="(ev) => this.onLineRentalQtyChange(line, ev)"
+                                />
                         </div>
 
                         <!-- Price Unit -->
                         <div class="col-2">
                             <div class="input-group input-group-sm">
                                 <span class="input-group-text">$</span>
-                                <input type="number" class="form-control" step="0.01"
-                                       t-att-value="line.priceUnit.toFixed(2)"
-                                       t-on-change="(ev) => this.onLinePriceUnitChange(line, ev)"/>
+                                <input
+                                        type="number"
+                                        class="form-control"
+                                        step="0.01"
+                                        t-att-value="line.priceUnit.toFixed(2)"
+                                        t-on-change="(ev) => this.onLinePriceUnitChange(line, ev)"
+                                    />
                             </div>
                         </div>
 
                         <!-- Total -->
                         <div class="col-1 text-end fw-semibold small">
-                            <t t-esc="formatCurrency(getLineTotal(line))"/>
+                            <t t-esc="formatCurrency(getLineSubtotal(line))" />
                         </div>
 
                         <!-- Delete -->
                         <div class="col-1 text-center">
-                            <button class="btn btn-link text-danger p-0" t-on-click="() => this.removeLine(line.id)"
-                                    t-att-disabled="state.modalData.lines.length === 1">
-                                <i class="fa fa-trash"/>
+                            <button
+                                    class="btn btn-link text-danger p-0"
+                                    t-on-click="() => this.removeLine(line.id)"
+                                    t-att-disabled="state.modalData.lines.length === 1"
+                                >
+                                <i class="fa fa-trash" />
                             </button>
                         </div>
                     </div>
@@ -337,7 +491,7 @@
                 <!-- Add Line Button -->
                 <div class="mb-4">
                     <a href="#" class="text-primary" t-on-click.prevent="addLine">
-                        <i class="fa fa-plus me-1"/>Add more equipment
+                        <i class="fa fa-plus me-1" />Add more equipment
                     </a>
                 </div>
 
@@ -346,7 +500,7 @@
                     <div class="col-md-4">
                         <div class="d-flex justify-content-between fw-bold fs-5">
                             <span>Total</span>
-                            <span><t t-esc="formatCurrency(modalTotal)"/></span>
+                            <span><t t-esc="formatCurrency(modalSubtotal)" /></span>
                         </div>
                     </div>
                 </div>
@@ -354,17 +508,26 @@
                 <!-- Modal Footer -->
                 <div class="d-flex justify-content-between">
                     <div class="d-flex gap-2" t-if="state.modalMode === 'edit'">
-                        <button class="btn btn-outline-primary px-3" t-on-click="openEditingOrder">
-                            <i class="fa fa-external-link me-2"/>View Order
+                        <button
+                                class="btn btn-outline-primary px-3"
+                                t-on-click="openEditingOrder"
+                            >
+                            <i class="fa fa-external-link me-2" />View Order
                         </button>
-                        <button class="btn btn-success px-3" t-on-click="confirmEditingOrder"
-                                t-att-disabled="state.modalData.state !== 'draft'">
-                            <i class="fa fa-check me-2"/>Confirm Order
+                        <button
+                                class="btn btn-success px-3"
+                                t-on-click="confirmEditingOrder"
+                                t-att-disabled="state.modalData.state !== 'draft'"
+                            >
+                            <i class="fa fa-check me-2" />Confirm Order
                         </button>
                     </div>
-                    <div t-else=""/>
+                    <div t-else="" />
                     <div class="d-flex gap-2">
-                        <button class="btn btn-outline-secondary px-4" t-on-click="closeModal">Cancel</button>
+                        <button
+                                class="btn btn-outline-secondary px-4"
+                                t-on-click="closeModal"
+                            >Cancel</button>
                         <button class="btn btn-primary px-4" t-on-click="confirmRental">
                             <t t-if="state.modalMode === 'edit'">Save Changes</t>
                             <t t-else="">Create Order</t>

--- a/rental_dashboard/static/src/xml/rental_dashboard.xml
+++ b/rental_dashboard/static/src/xml/rental_dashboard.xml
@@ -1,0 +1,379 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="rental_dashboard.RentalDashboard" owl="1">
+        <div class="rental-dashboard d-flex h-100">
+            <!-- Left Sidebar -->
+            <div class="rental-sidebar border-end bg-white p-3" style="width: 320px; min-width: 320px; overflow-y: auto;">
+                <!-- Create Rental Button -->
+                <button class="btn w-50 mb-4"
+                        style="background-color: cornflowerblue; color: white;"
+                        t-on-click="openCreateModal">
+                    <i class="fa fa-plus me-2"/>Create rental
+                </button>
+
+                <!-- Search Section -->
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                    <h6 class="mb-0 fw-bold">Search rentals</h6>
+                    <a href="#" class="text-muted small" t-on-click.prevent="clearFilters">
+                        <i class="fa fa-times me-1"/>Clear filters
+                    </a>
+                </div>
+
+                <!-- Location Filter -->
+                <div class="mb-3">
+                    <label class="form-label small text-muted">Location</label>
+                    <select class="form-select" t-on-change="onLocationChange">
+                        <option value="">Select a location</option>
+                        <t t-foreach="state.locations" t-as="loc" t-key="loc.id">
+                            <option t-att-value="loc.id" t-att-selected="state.selectedLocation === loc.id">
+                                <t t-esc="loc.name"/>
+                            </option>
+                        </t>
+                    </select>
+                </div>
+
+                <!-- Date Range Filter -->
+                <div class="mb-3">
+                    <label class="form-label small text-muted">Dates</label>
+                    <div class="date-range-picker position-relative">
+                        <div class="form-control d-flex align-items-center justify-content-between cursor-pointer"
+                             t-on-click="toggleDatePicker">
+                            <span t-if="state.dateFrom and state.dateTo">
+                                <t t-esc="formatDateRange()"/>
+                            </span>
+                            <span t-else="" class="text-muted">Select dates</span>
+                            <i class="fa fa-calendar"/>
+                        </div>
+                        <!-- Date picker dropdown -->
+                        <div t-if="state.showDatePicker" class="date-picker-dropdown position-absolute bg-white border rounded shadow-sm p-3 mt-1" style="z-index: 1000; width: 100%;">
+                            <div class="mb-2">
+                                <label class="form-label small">From</label>
+                                <input type="date" class="form-control"
+                                       t-att-value="state.dateFrom"
+                                       t-on-change="onDateFromChange"/>
+                            </div>
+                            <div class="mb-2">
+                                <label class="form-label small">To</label>
+                                <input type="date" class="form-control"
+                                       t-att-value="state.dateTo"
+                                       t-on-change="onDateToChange"/>
+                            </div>
+                            <div class="d-flex justify-content-end gap-2">
+                                <button class="btn btn-sm btn-outline-secondary" t-on-click="clearDateFilter">Clear</button>
+                                <button class="btn btn-sm btn-primary" t-on-click="applyDateFilter">Apply</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Show Available Only -->
+                <div class="form-check mb-4">
+                    <input type="checkbox" class="form-check-input" id="showAvailable"
+                           t-att-checked="state.showAvailableOnly"
+                           t-on-change="onShowAvailableChange"/>
+                    <label class="form-check-label" for="showAvailable">Show available only</label>
+                </div>
+
+                <!-- Products List -->
+                <div class="products-list">
+                    <t t-foreach="filteredProducts" t-as="product" t-key="product.id">
+                        <div t-att-class="'product-card border rounded p-2 mb-2 ' +
+                             (isProductSelected(product.id) ? 'border-primary bg-primary-subtle' : 'bg-light') +
+                             (product.qty_available === 0 ? ' product-unavailable' : '')"
+                             t-on-click="() => product.qty_available > 0 &amp;&amp; this.onProductSelect(product.id)">
+                            <div class="d-flex align-items-start">
+                                <!-- Checkbox -->
+                                <input type="checkbox" class="form-check-input me-2 mt-1"
+                                       t-att-checked="isProductSelected(product.id)"
+                                       t-att-disabled="product.qty_available === 0"
+                                       t-on-click.stop="() => product.qty_available > 0 &amp;&amp; this.onProductSelect(product.id)"/>
+
+                                <!-- Color dot -->
+                                <span class="product-color-dot me-2 mt-1" t-att-style="getProductColorStyle(product)"/>
+
+                                <div class="flex-grow-1">
+                                    <!-- Availability Badge -->
+                                    <span t-att-class="'badge rounded-pill mt-1 float-end ' + getAvailabilityClass(product)">
+                                        <i class="fa fa-check me-1" t-if="product.qty_available > 0"/>
+                                        <i class="fa fa-times me-1" t-if="product.qty_available === 0"/>
+                                        <t t-esc="getAvailabilityText(product)"/>
+                                    </span>
+
+                                    <!-- Product Name -->
+                                    <div class="fw-semibold">
+                                        <t t-esc="product.name"/>
+                                    </div>
+
+                                    <!-- Stock: available / total -->
+                                    <div class="mt-1 small text-muted">
+                                        <i class="fa fa-cubes me-1"/>
+                                        <t t-esc="product.qty_available"/> available
+                                        <span class="text-muted"> / <t t-esc="product.qty_total"/> total</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </t>
+
+                    <div t-if="filteredProducts.length === 0" class="text-muted text-center py-4">
+                        No products found
+                    </div>
+                </div>
+
+                <!-- Rent Button (shows when products are selected) -->
+                <div t-if="state.selectedProducts.length > 0" class="mt-3">
+                    <button class="btn btn-outline-dark w-100 py-2" t-on-click="openCreateModal">
+                        Rent
+                    </button>
+                </div>
+            </div>
+
+            <!-- Right Calendar Area - Embedded Calendar -->
+            <div class="rental-calendar flex-grow-1" style="overflow: hidden;" t-ref="calendarContainer">
+                <t t-if="calendarProps">
+                    <View t-key="state.calendarKey" t-props="calendarProps"/>
+                </t>
+                <t t-else="">
+                    <div class="d-flex align-items-center justify-content-center h-100 bg-light">
+                        <div class="text-center">
+                            <i class="fa fa-spinner fa-spin fa-3x text-muted mb-3"/>
+                            <p class="text-muted">Loading calendar...</p>
+                        </div>
+                    </div>
+                </t>
+            </div>
+        </div>
+
+        <!-- Tooltip is managed by plain DOM in JS to avoid OWL re-renders -->
+
+        <!-- Create/Edit Rental Modal -->
+        <div t-if="state.showModal" class="rental-modal-backdrop" t-on-click="closeModal">
+            <div class="rental-modal" t-on-click.stop="">
+
+                <!-- Created Success State -->
+                <t t-if="state.modalMode === 'created'">
+                    <div class="text-center py-5">
+                        <i class="fa fa-check-circle text-success fa-4x mb-3"/>
+                        <h4 class="fw-bold mb-4">Rental Order Created</h4>
+                        <div class="d-flex justify-content-center gap-3">
+                            <button class="btn btn-outline-primary px-4" t-on-click="openCreatedOrder">
+                                <i class="fa fa-external-link me-2"/>View Sale Order
+                            </button>
+                            <button class="btn btn-primary px-4" t-on-click="confirmCreatedOrder">
+                                <i class="fa fa-check me-2"/>Confirm Order
+                            </button>
+                        </div>
+                        <div class="mt-4">
+                            <button class="btn btn-outline-secondary px-4 py-2 rounded-pill shadow-sm"
+                                    t-on-click="closeModal">
+                                <i class="fa fa-times me-2 text-danger"/>Close
+                            </button>
+                        </div>
+                    </div>
+                </t>
+
+                <!-- Form State (create / edit) -->
+                <t t-else="">
+                <!-- Modal Header -->
+                <div class="d-flex justify-content-between align-items-center mb-4">
+                    <div class="d-flex align-items-center gap-3">
+                        <h4 class="mb-0 fw-bold">
+                            <t t-if="state.modalMode === 'edit'">Edit Rental Order</t>
+                            <t t-else="">New Rental Order</t>
+                        </h4>
+                        <t t-if="state.modalMode === 'edit' and state.modalData.state">
+                            <span t-att-class="'badge ' + getStatusBadgeClass(state.modalData.state)">
+                                <t t-esc="getStatusLabel(state.modalData.state)"/>
+                            </span>
+                        </t>
+                    </div>
+                    <button class="btn btn-link text-dark p-0" t-on-click="closeModal">
+                        <i class="fa fa-times fa-lg"/>
+                    </button>
+                </div>
+
+                <!-- Modal Form -->
+                <div class="row mb-4">
+                    <!-- Location (Warehouse) -->
+                    <div class="col-md-3">
+                        <label class="form-label small text-muted">Warehouse</label>
+                        <select class="form-select" t-on-change="onModalLocationChange">
+                            <option value="">Select warehouse</option>
+                            <t t-foreach="state.locations" t-as="loc" t-key="loc.id">
+                                <option t-att-value="loc.id" t-att-selected="state.modalData.locationId === loc.id">
+                                    <t t-esc="loc.name"/>
+                                </option>
+                            </t>
+                        </select>
+                    </div>
+
+                    <!-- Customer -->
+                    <div class="col-md-3">
+                        <label class="form-label small text-muted">Customer</label>
+                        <div class="position-relative">
+                            <input type="text" class="form-control"
+                                   placeholder="Search customer..."
+                                   t-att-value="state.modalData.customerSearch"
+                                   t-on-input="onCustomerSearch"/>
+                            <i class="fa fa-search position-absolute" style="right: 12px; top: 50%; transform: translateY(-50%); color: #6c757d;"/>
+                            <div t-if="state.customers.length > 0" class="position-absolute bg-white border rounded shadow-sm w-100 mt-1" style="z-index: 1001; max-height: 200px; overflow-y: auto;">
+                                <t t-foreach="state.customers" t-as="customer" t-key="customer.id">
+                                    <div class="p-2 cursor-pointer customer-option" t-on-click="() => this.selectCustomer(customer)">
+                                        <div><t t-esc="customer.name"/></div>
+                                        <small class="text-muted" t-if="customer.email"><t t-esc="customer.email"/></small>
+                                    </div>
+                                </t>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Start Date -->
+                    <div class="col-md-3">
+                        <label class="form-label small text-muted">Start date</label>
+                        <input type="date" class="form-control"
+                               t-att-value="state.modalData.startDate"
+                               t-on-change="onModalStartDateChange"/>
+                    </div>
+
+                    <!-- End Date -->
+                    <div class="col-md-3">
+                        <label class="form-label small text-muted">End date</label>
+                        <input type="date" class="form-control"
+                               t-att-value="state.modalData.endDate"
+                               t-on-change="onModalEndDateChange"/>
+                    </div>
+                </div>
+
+                <!-- Rental Details -->
+                <h5 class="fw-bold mb-3">Rental details</h5>
+
+                <!-- Lines Header -->
+                <div class="row mb-2 small text-muted fw-semibold">
+                    <div class="col-3">Equipment</div>
+                    <div class="col-2">Type</div>
+                    <div class="col-2">Period</div>
+                    <div class="col-1">Qty</div>
+                    <div class="col-2">Price/Unit</div>
+                    <div class="col-1 text-end">Total</div>
+                    <div class="col-1"></div>
+                </div>
+
+                <!-- Lines -->
+                <t t-foreach="state.modalData.lines" t-as="line" t-key="line.id">
+                    <div class="row mb-2 align-items-center">
+                        <!-- Equipment (rental service product) -->
+                        <div class="col-3">
+                            <select class="form-select form-select-sm" t-on-change="(ev) => this.onLineProductChange(line, ev)">
+                                <option value="">Select equipment</option>
+                                <t t-foreach="state.modalProducts" t-as="product" t-key="product.id">
+                                    <option t-att-value="product.id" t-att-selected="line.productId === product.id">
+                                        <t t-esc="product.name"/>
+                                    </option>
+                                </t>
+                            </select>
+                            <small class="text-success d-block" t-if="line.available > 0">
+                                <i class="fa fa-check"/> <t t-esc="line.available"/> avail.
+                            </small>
+                            <small class="text-danger d-block" t-else="">
+                                <i class="fa fa-times"/> Unavailable
+                            </small>
+                        </div>
+
+                        <!-- Rental Type -->
+                        <div class="col-2">
+                            <select class="form-select form-select-sm"
+                                    t-on-change="(ev) => this.onLineRentalTypeChange(line, ev)">
+                                <option value="new_rental" t-att-selected="line.rentalType === 'new_rental'">New Rental</option>
+                                <option value="rental_extension" t-att-selected="line.rentalType === 'rental_extension'">Extension</option>
+                            </select>
+                        </div>
+
+                        <!-- Rental Period -->
+                        <div class="col-2">
+                            <select class="form-select form-select-sm"
+                                    t-on-change="(ev) => this.onLineRentalPeriodChange(line, ev)">
+<!--                                <option value="" disabled="1">Period</option>-->
+                                <t t-foreach="getLineAvailablePeriods(line)" t-as="period" t-key="period.id">
+                                    <option t-att-value="period.id" t-att-selected="line.rentalPeriodId === period.id">
+                                        <t t-esc="period.name"/>
+                                    </option>
+                                </t>
+                            </select>
+                        </div>
+
+                        <!-- Rental Qty -->
+                        <div class="col-1">
+                            <input type="number" class="form-control form-control-sm text-center" min="1" step="1"
+                                   t-att-value="line.rentalQty"
+                                   t-on-change="(ev) => this.onLineRentalQtyChange(line, ev)"/>
+                        </div>
+
+                        <!-- Price Unit -->
+                        <div class="col-2">
+                            <div class="input-group input-group-sm">
+                                <span class="input-group-text">$</span>
+                                <input type="number" class="form-control" step="0.01"
+                                       t-att-value="line.priceUnit.toFixed(2)"
+                                       t-on-change="(ev) => this.onLinePriceUnitChange(line, ev)"/>
+                            </div>
+                        </div>
+
+                        <!-- Total -->
+                        <div class="col-1 text-end fw-semibold small">
+                            <t t-esc="formatCurrency(getLineTotal(line))"/>
+                        </div>
+
+                        <!-- Delete -->
+                        <div class="col-1 text-center">
+                            <button class="btn btn-link text-danger p-0" t-on-click="() => this.removeLine(line.id)"
+                                    t-att-disabled="state.modalData.lines.length === 1">
+                                <i class="fa fa-trash"/>
+                            </button>
+                        </div>
+                    </div>
+                </t>
+
+                <!-- Add Line Button -->
+                <div class="mb-4">
+                    <a href="#" class="text-primary" t-on-click.prevent="addLine">
+                        <i class="fa fa-plus me-1"/>Add more equipment
+                    </a>
+                </div>
+
+                <!-- Totals -->
+                <div class="row justify-content-end mb-4">
+                    <div class="col-md-4">
+                        <div class="d-flex justify-content-between fw-bold fs-5">
+                            <span>Total</span>
+                            <span><t t-esc="formatCurrency(modalTotal)"/></span>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Modal Footer -->
+                <div class="d-flex justify-content-between">
+                    <div class="d-flex gap-2" t-if="state.modalMode === 'edit'">
+                        <button class="btn btn-outline-primary px-3" t-on-click="openEditingOrder">
+                            <i class="fa fa-external-link me-2"/>View Order
+                        </button>
+                        <button class="btn btn-success px-3" t-on-click="confirmEditingOrder"
+                                t-att-disabled="state.modalData.state !== 'draft'">
+                            <i class="fa fa-check me-2"/>Confirm Order
+                        </button>
+                    </div>
+                    <div t-else=""/>
+                    <div class="d-flex gap-2">
+                        <button class="btn btn-outline-secondary px-4" t-on-click="closeModal">Cancel</button>
+                        <button class="btn btn-primary px-4" t-on-click="confirmRental">
+                            <t t-if="state.modalMode === 'edit'">Save Changes</t>
+                            <t t-else="">Create Order</t>
+                        </button>
+                    </div>
+                </div>
+                </t>
+            </div>
+        </div>
+    </t>
+
+</templates>

--- a/rental_dashboard/tests/__init__.py
+++ b/rental_dashboard/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_rental_dashboard

--- a/rental_dashboard/tests/test_rental_dashboard.py
+++ b/rental_dashboard/tests/test_rental_dashboard.py
@@ -1,0 +1,299 @@
+# Copyright 2024 OCA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase
+
+
+class RentalDashboardCommon(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env["res.partner"].create({"name": "Test Dashboard Partner"})
+        cls.warehouse = cls.env.ref("stock.warehouse0")
+        cls.warehouse.write({"rental_allowed": True})
+        cls.rental_in_loc = cls.warehouse.rental_in_location_id
+
+        cls.physical = cls.env["product.product"].create(
+            {"name": "Dashboard Physical Product", "type": "product"}
+        )
+        cls.service = cls.env["product.product"].create(
+            {
+                "name": "Dashboard Rental Service",
+                "type": "service",
+                "must_have_dates": True,
+                "rented_product_id": cls.physical.id,
+            }
+        )
+        # rental field lives on product.template (from rental_base).
+        # Set it there so the stored compute on sale.order.line picks it up.
+        if "rental" in cls.env["product.template"]._fields:
+            cls.service.product_tmpl_id.write({"rental": True})
+        cls.env["stock.quant"].create(
+            {
+                "product_id": cls.physical.id,
+                "location_id": cls.rental_in_loc.id,
+                "quantity": 10.0,
+            }
+        )
+        cls.rental_period = cls.env["rental.period"].search([], limit=1)
+        if not cls.rental_period:
+            cls.rental_period = cls.env["rental.period"].create(
+                {"name": "Day", "code": "day", "hours_per_unit": 24}
+            )
+
+    def _rental_order_vals(self, **line_overrides):
+        line = {
+            "product_id": self.service.id,
+            "rental_type": "new_rental",
+            "rental_qty": 1.0,
+            "rental_period_id": self.rental_period.id,
+            "start_datetime": "2024-01-01 08:00:00",
+            "end_datetime": "2024-01-10 08:00:00",
+            "product_uom_qty": 9.0,
+            "price_unit": 100.0,
+        }
+        line.update(line_overrides)
+        return {
+            "partner_id": self.partner.id,
+            "warehouse_id": self.warehouse.id,
+            "lines": [line],
+        }
+
+
+class TestRentalDashboardSaleOrderLine(RentalDashboardCommon):
+    def test_compute_rental_display_name_non_rental(self):
+        """Non-rental line (plain service product) falls back to line.name."""
+        # Use a plain service product with no rental setup so line.rental=False
+        plain_product = self.env["product.product"].create(
+            {"name": "Plain Service", "type": "service"}
+        )
+        order = self.env["sale.order"].create({"partner_id": self.partner.id})
+        line = self.env["sale.order.line"].create(
+            {
+                "order_id": order.id,
+                "product_id": plain_product.id,
+                "name": "Plain line",
+                "price_unit": 0,
+                "product_uom_qty": 1,
+            }
+        )
+        self.assertEqual(line.rental_display_name, "Plain line")
+
+    def test_compute_rental_display_name_rental(self):
+        """Rental line includes the product display name."""
+        order = self.env["sale.order"].create({"partner_id": self.partner.id})
+        line = self.env["sale.order.line"].create(
+            {
+                "order_id": order.id,
+                "product_id": self.service.id,
+                "name": "Rental line",
+                "price_unit": 100,
+                "product_uom_qty": 1,
+                "rental": True,
+                "rental_qty": 1.0,
+                "rental_period_id": self.rental_period.id,
+                "start_datetime": "2024-01-01 08:00:00",
+                "end_datetime": "2024-01-02 08:00:00",
+            }
+        )
+        self.assertIn(self.service.display_name, line.rental_display_name)
+
+    def test_compute_rental_display_name_with_location(self):
+        """Rental line with warehouse location includes location name."""
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "warehouse_id": self.warehouse.id,
+            }
+        )
+        line = self.env["sale.order.line"].create(
+            {
+                "order_id": order.id,
+                "product_id": self.service.id,
+                "name": "Rental line",
+                "price_unit": 100,
+                "product_uom_qty": 1,
+                "rental": True,
+                "rental_qty": 1.0,
+                "rental_period_id": self.rental_period.id,
+                "start_datetime": "2024-01-01 08:00:00",
+                "end_datetime": "2024-01-02 08:00:00",
+            }
+        )
+        if self.rental_in_loc:
+            self.assertIn(self.rental_in_loc.name, line.rental_display_name)
+
+    def test_create_rental_order(self):
+        """create_rental_order creates a sale order with one rental line."""
+        SolEnv = self.env["sale.order.line"]
+        order_id = SolEnv.create_rental_order(self._rental_order_vals())
+
+        self.assertIsInstance(order_id, int)
+        order = self.env["sale.order"].browse(order_id)
+        self.assertEqual(order.partner_id, self.partner)
+        self.assertEqual(order.warehouse_id, self.warehouse)
+        self.assertEqual(len(order.order_line), 1)
+
+        line = order.order_line[0]
+        self.assertTrue(line.rental)
+        self.assertEqual(line.product_id, self.service)
+        self.assertEqual(line.rental_qty, 1.0)
+
+    def test_create_rental_order_no_lines(self):
+        """create_rental_order with empty lines creates an order without lines."""
+        order_id = self.env["sale.order.line"].create_rental_order(
+            {
+                "partner_id": self.partner.id,
+                "warehouse_id": self.warehouse.id,
+                "lines": [],
+            }
+        )
+        order = self.env["sale.order"].browse(order_id)
+        self.assertFalse(order.order_line)
+
+    def test_update_rental_order(self):
+        """update_rental_order replaces rental lines on the order."""
+        SolEnv = self.env["sale.order.line"]
+        order_id = SolEnv.create_rental_order(self._rental_order_vals())
+
+        new_service = self.env["product.product"].create(
+            {
+                "name": "Second Rental Service",
+                "type": "service",
+                "must_have_dates": True,
+                "rented_product_id": self.physical.id,
+            }
+        )
+        SolEnv.update_rental_order(
+            order_id,
+            self._rental_order_vals(
+                product_id=new_service.id,
+                rental_qty=2.0,
+                start_datetime="2024-02-01 08:00:00",
+                end_datetime="2024-02-05 08:00:00",
+                product_uom_qty=8.0,
+            ),
+        )
+
+        order = self.env["sale.order"].browse(order_id)
+        self.assertEqual(len(order.order_line), 1)
+        self.assertEqual(order.order_line[0].product_id, new_service)
+        self.assertEqual(order.order_line[0].rental_qty, 2.0)
+
+    def test_get_rental_order_edit_data(self):
+        """get_rental_order_edit_data returns structured data for editing."""
+        SolEnv = self.env["sale.order.line"]
+        order_id = SolEnv.create_rental_order(self._rental_order_vals())
+        line_id = self.env["sale.order"].browse(order_id).order_line[0].id
+
+        result = SolEnv.get_rental_order_edit_data(line_id)
+
+        self.assertIsNotNone(result)
+        self.assertIn("order", result)
+        self.assertIn("lines", result)
+        self.assertIn("location_id", result)
+        self.assertIn("modal_products", result)
+        self.assertEqual(result["order"]["id"], order_id)
+        self.assertEqual(len(result["lines"]), 1)
+
+    def test_get_rental_order_edit_data_nonexistent(self):
+        """get_rental_order_edit_data returns None for a non-existent line ID."""
+        result = self.env["sale.order.line"].get_rental_order_edit_data(999999999)
+        self.assertIsNone(result)
+
+
+class TestRentalDashboardProduct(RentalDashboardCommon):
+    def test_get_rental_dashboard_data_keys(self):
+        """get_rental_dashboard_data returns all expected top-level keys."""
+        result = self.env["product.product"].get_rental_dashboard_data()
+        self.assertIn("locations", result)
+        self.assertIn("warehouses", result)
+        self.assertIn("rental_periods", result)
+        self.assertIn("products", result)
+
+    def test_get_rental_dashboard_data_with_location(self):
+        """get_rental_dashboard_data accepts a location_id filter."""
+        result = self.env["product.product"].get_rental_dashboard_data(
+            location_id=self.rental_in_loc.id
+        )
+        self.assertIsInstance(result["products"], list)
+
+    def test_get_rental_dashboard_data_with_dates(self):
+        """get_rental_dashboard_data accepts date filters."""
+        result = self.env["product.product"].get_rental_dashboard_data(
+            date_from="2024-01-01", date_to="2024-01-31"
+        )
+        self.assertIsInstance(result["products"], list)
+
+    def test_get_rental_products(self):
+        """get_rental_products returns a list."""
+        result = self.env["product.product"].get_rental_products()
+        self.assertIsInstance(result, list)
+
+    def test_get_rental_products_with_location(self):
+        """get_rental_products filtered by location returns a list."""
+        result = self.env["product.product"].get_rental_products(
+            location_id=self.rental_in_loc.id
+        )
+        self.assertIsInstance(result, list)
+
+    def test_get_rental_modal_products(self):
+        """get_rental_modal_products returns a list."""
+        result = self.env["product.product"].get_rental_modal_products()
+        self.assertIsInstance(result, list)
+
+    def test_get_rental_modal_products_with_location(self):
+        """get_rental_modal_products filtered by location returns a list."""
+        result = self.env["product.product"].get_rental_modal_products(
+            location_id=self.rental_in_loc.id
+        )
+        self.assertIsInstance(result, list)
+
+    def test_get_rental_modal_products_with_dates(self):
+        """get_rental_modal_products with date range filters committed rentals."""
+        result = self.env["product.product"].get_rental_modal_products(
+            location_id=self.rental_in_loc.id,
+            date_from="2024-01-01",
+            date_to="2024-01-31",
+        )
+        self.assertIsInstance(result, list)
+
+    def test_check_rental_availability_sufficient_stock(self):
+        """check_rental_availability returns no errors when stock is sufficient."""
+        errors = self.env["product.product"].check_rental_availability(
+            location_id=self.rental_in_loc.id,
+            start_date="2024-03-01",
+            end_date="2024-03-10",
+            lines=[{"product_id": self.service.id, "rental_qty": 2.0}],
+        )
+        self.assertEqual(errors, [])
+
+    def test_check_rental_availability_insufficient_stock(self):
+        """check_rental_availability returns an error when qty exceeds stock."""
+        errors = self.env["product.product"].check_rental_availability(
+            location_id=self.rental_in_loc.id,
+            start_date="2024-03-01",
+            end_date="2024-03-10",
+            lines=[{"product_id": self.service.id, "rental_qty": 100.0}],
+        )
+        self.assertTrue(errors)
+        self.assertIn(self.physical.display_name, errors[0])
+
+    def test_check_rental_availability_empty_lines(self):
+        """check_rental_availability with no lines returns no errors."""
+        errors = self.env["product.product"].check_rental_availability(
+            location_id=self.rental_in_loc.id,
+            start_date="2024-03-01",
+            end_date="2024-03-10",
+            lines=[],
+        )
+        self.assertEqual(errors, [])
+
+    def test_rental_color_field_default(self):
+        """rental_color defaults to 0."""
+        self.assertEqual(self.physical.rental_color, 0)
+
+    def test_rental_color_field_write(self):
+        """rental_color can be updated."""
+        self.physical.write({"rental_color": 5})
+        self.assertEqual(self.physical.rental_color, 5)

--- a/rental_dashboard/views/dashboard_action.xml
+++ b/rental_dashboard/views/dashboard_action.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <odoo>
 
     <!-- Custom Dashboard Action -->

--- a/rental_dashboard/views/dashboard_action.xml
+++ b/rental_dashboard/views/dashboard_action.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Custom Dashboard Action -->
+    <record id="rental_dashboard_action_client" model="ir.actions.client">
+        <field name="name">Rental Dashboard</field>
+        <field name="tag">rental_dashboard.dashboard</field>
+    </record>
+
+</odoo>

--- a/rental_dashboard/views/menus.xml
+++ b/rental_dashboard/views/menus.xml
@@ -1,21 +1,20 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
 
-    <!-- Main Menu -->
-    <menuitem
-        id="menu_rental_root"
-        name="Rentals"
-        sequence="50"
-        web_icon="rental_dashboard,static/description/icon.png"
-    />
-
     <!-- Dashboard Menu - Custom OWL Component -->
     <menuitem
         id="menu_rental_dashboard"
-        name="Dashboard"
-        parent="menu_rental_root"
+        name="Rental Dashboard"
+        parent="sale.sale_order_menu"
         action="rental_dashboard_action_client"
         sequence="10"
     />
+    <record id="sale_rental.sale_rental_menu" model="ir.ui.menu">
+        <field name="sequence">11</field>
+    </record>
+
+    <record id="sale_rental.menu_rental_report_dashboard" model="ir.ui.menu">
+        <field name="sequence">11</field>
+    </record>
 
 </odoo>

--- a/rental_dashboard/views/menus.xml
+++ b/rental_dashboard/views/menus.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Main Menu -->
+    <menuitem id="menu_rental_root"
+              name="Rentals"
+              sequence="50"
+              web_icon="rental_dashboard,static/description/icon.png"/>
+
+    <!-- Dashboard Menu - Custom OWL Component -->
+    <menuitem id="menu_rental_dashboard"
+              name="Dashboard"
+              parent="menu_rental_root"
+              action="rental_dashboard_action_client"
+              sequence="10"/>
+
+</odoo>

--- a/rental_dashboard/views/menus.xml
+++ b/rental_dashboard/views/menus.xml
@@ -1,17 +1,21 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <odoo>
 
     <!-- Main Menu -->
-    <menuitem id="menu_rental_root"
-              name="Rentals"
-              sequence="50"
-              web_icon="rental_dashboard,static/description/icon.png"/>
+    <menuitem
+        id="menu_rental_root"
+        name="Rentals"
+        sequence="50"
+        web_icon="rental_dashboard,static/description/icon.png"
+    />
 
     <!-- Dashboard Menu - Custom OWL Component -->
-    <menuitem id="menu_rental_dashboard"
-              name="Dashboard"
-              parent="menu_rental_root"
-              action="rental_dashboard_action_client"
-              sequence="10"/>
+    <menuitem
+        id="menu_rental_dashboard"
+        name="Dashboard"
+        parent="menu_rental_root"
+        action="rental_dashboard_action_client"
+        sequence="10"
+    />
 
 </odoo>

--- a/rental_dashboard/views/product_product_views.xml
+++ b/rental_dashboard/views/product_product_views.xml
@@ -97,7 +97,7 @@
         <field name="name">product.product.tree.rental</field>
         <field name="model">product.product</field>
         <field name="arch" type="xml">
-            <tree string="Rental Products" multi_edit="1">
+            <tree multi_edit="1">
                 <field name="name" />
                 <field name="default_code" optional="show" />
                 <field name="qty_available" string="On Hand" />

--- a/rental_dashboard/views/product_product_views.xml
+++ b/rental_dashboard/views/product_product_views.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Extend product.product form to add rental_color -->
+    <record id="product_product_form_view_rental" model="ir.ui.view">
+        <field name="name">product.product.form.rental.color</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_normal_form_view"/>
+        <field name="arch" type="xml">
+            <group name="sale" position="inside">
+                <field name="rental_color" widget="color_picker"
+                       attrs="{'invisible': [('rental_service_ids', '=', [])]}"/>
+            </group>
+        </field>
+    </record>
+
+    <!-- Kanban View for Rental Products (product.product) -->
+    <record id="product_product_kanban_view_rental" model="ir.ui.view">
+        <field name="name">product.product.kanban.rental</field>
+        <field name="model">product.product</field>
+        <field name="arch" type="xml">
+            <kanban class="o_kanban_mobile" sample="1">
+                <field name="id"/>
+                <field name="name"/>
+                <field name="default_code"/>
+                <field name="qty_available"/>
+                <field name="rental_color"/>
+                <field name="rental_service_ids"/>
+                <field name="image_128"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div t-attf-class="oe_kanban_global_click oe_kanban_card">
+                            <!-- Color indicator -->
+                            <div t-attf-class="oe_kanban_color_#{kanban_getcolor(record.rental_color.raw_value)}"
+                                 style="height: 4px; margin-bottom: 8px;"/>
+
+                            <div class="o_kanban_image">
+                                <img t-att-src="kanban_image('product.product', 'image_128', record.id.raw_value)"
+                                     alt="Product" class="o_image_64_cover"/>
+                            </div>
+
+                            <div class="oe_kanban_details">
+                                <strong class="o_kanban_record_title">
+                                    <field name="name"/>
+                                </strong>
+
+                                <div t-if="record.default_code.value" class="text-muted small">
+                                    [<field name="default_code"/>]
+                                </div>
+
+                                <!-- Stock availability -->
+                                <div class="mt-2">
+                                    <span t-if="record.qty_available.raw_value > 5"
+                                          class="badge rounded-pill text-bg-success">
+                                        <i class="fa fa-check"/> <field name="qty_available"/> Available
+                                    </span>
+                                    <span t-elif="record.qty_available.raw_value > 0"
+                                          class="badge rounded-pill text-bg-warning">
+                                        <i class="fa fa-exclamation"/> <field name="qty_available"/> Left
+                                    </span>
+                                    <span t-else="" class="badge rounded-pill text-bg-danger">
+                                        <i class="fa fa-times"/> Unavailable
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
+    <!-- Tree View for Rental Products (product.product) -->
+    <record id="product_product_tree_view_rental" model="ir.ui.view">
+        <field name="name">product.product.tree.rental</field>
+        <field name="model">product.product</field>
+        <field name="arch" type="xml">
+            <tree string="Rental Products" multi_edit="1">
+                <field name="name"/>
+                <field name="default_code" optional="show"/>
+                <field name="qty_available" string="On Hand"/>
+                <field name="rental_color" widget="color_picker" optional="hide"/>
+            </tree>
+        </field>
+    </record>
+
+    <!-- Search View for Rental Products (product.product) -->
+    <record id="product_product_search_view_rental" model="ir.ui.view">
+        <field name="name">product.product.search.rental</field>
+        <field name="model">product.product</field>
+        <field name="arch" type="xml">
+            <search string="Search Rental Products">
+                <field name="name"/>
+                <field name="default_code"/>
+                <field name="categ_id"/>
+
+                <separator/>
+                <filter name="filter_in_stock" string="In Stock"
+                        domain="[('qty_available', '&gt;', 0)]"/>
+                <filter name="filter_out_of_stock" string="Out of Stock"
+                        domain="[('qty_available', '&lt;=', 0)]"/>
+
+                <separator/>
+                <group expand="0" string="Group By">
+                    <filter name="group_categ" string="Category"
+                            context="{'group_by': 'categ_id'}"/>
+                    <filter name="group_type" string="Product Type"
+                            context="{'group_by': 'detailed_type'}"/>
+                </group>
+
+                <searchpanel>
+                    <field name="categ_id" icon="fa-folder" enable_counters="1"/>
+                </searchpanel>
+            </search>
+        </field>
+    </record>
+
+    <!-- Main Action for Rental Products -->
+    <record id="product_product_rental_action" model="ir.actions.act_window">
+        <field name="name">Rental Products</field>
+        <field name="res_model">product.product</field>
+        <field name="view_mode">kanban,tree,form</field>
+        <field name="search_view_id" ref="product_product_search_view_rental"/>
+        <field name="domain">[('rental_service_ids', '!=', False)]</field>
+        <field name="context">{'search_default_filter_in_stock': 1}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No rental products found.
+            </p>
+            <p>
+                Create a physical product and then use "Create Rental Service"
+                on its form to make it available for rental.
+            </p>
+        </field>
+    </record>
+
+    <!-- Explicit view references for action -->
+    <record id="product_product_rental_action_view_kanban" model="ir.actions.act_window.view">
+        <field name="sequence">1</field>
+        <field name="view_mode">kanban</field>
+        <field name="view_id" ref="product_product_kanban_view_rental"/>
+        <field name="act_window_id" ref="product_product_rental_action"/>
+    </record>
+
+    <record id="product_product_rental_action_view_tree" model="ir.actions.act_window.view">
+        <field name="sequence">2</field>
+        <field name="view_mode">tree</field>
+        <field name="view_id" ref="product_product_tree_view_rental"/>
+        <field name="act_window_id" ref="product_product_rental_action"/>
+    </record>
+
+</odoo>

--- a/rental_dashboard/views/product_product_views.xml
+++ b/rental_dashboard/views/product_product_views.xml
@@ -1,15 +1,18 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <odoo>
 
     <!-- Extend product.product form to add rental_color -->
     <record id="product_product_form_view_rental" model="ir.ui.view">
         <field name="name">product.product.form.rental.color</field>
         <field name="model">product.product</field>
-        <field name="inherit_id" ref="product.product_normal_form_view"/>
+        <field name="inherit_id" ref="product.product_normal_form_view" />
         <field name="arch" type="xml">
             <group name="sale" position="inside">
-                <field name="rental_color" widget="color_picker"
-                       attrs="{'invisible': [('rental_service_ids', '=', [])]}"/>
+                <field
+                    name="rental_color"
+                    widget="color_picker"
+                    attrs="{'invisible': [('rental_service_ids', '=', [])]}"
+                />
             </group>
         </field>
     </record>
@@ -20,46 +23,65 @@
         <field name="model">product.product</field>
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile" sample="1">
-                <field name="id"/>
-                <field name="name"/>
-                <field name="default_code"/>
-                <field name="qty_available"/>
-                <field name="rental_color"/>
-                <field name="rental_service_ids"/>
-                <field name="image_128"/>
+                <field name="id" />
+                <field name="name" />
+                <field name="default_code" />
+                <field name="qty_available" />
+                <field name="rental_color" />
+                <field name="rental_service_ids" />
+                <field name="image_128" />
                 <templates>
                     <t t-name="kanban-box">
                         <div t-attf-class="oe_kanban_global_click oe_kanban_card">
                             <!-- Color indicator -->
-                            <div t-attf-class="oe_kanban_color_#{kanban_getcolor(record.rental_color.raw_value)}"
-                                 style="height: 4px; margin-bottom: 8px;"/>
+                            <div
+                                t-attf-class="oe_kanban_color_#{kanban_getcolor(record.rental_color.raw_value)}"
+                                style="height: 4px; margin-bottom: 8px;"
+                            />
 
                             <div class="o_kanban_image">
-                                <img t-att-src="kanban_image('product.product', 'image_128', record.id.raw_value)"
-                                     alt="Product" class="o_image_64_cover"/>
+                                <img
+                                    t-att-src="kanban_image('product.product', 'image_128', record.id.raw_value)"
+                                    alt="Product"
+                                    class="o_image_64_cover"
+                                />
                             </div>
 
                             <div class="oe_kanban_details">
                                 <strong class="o_kanban_record_title">
-                                    <field name="name"/>
+                                    <field name="name" />
                                 </strong>
 
-                                <div t-if="record.default_code.value" class="text-muted small">
-                                    [<field name="default_code"/>]
+                                <div
+                                    t-if="record.default_code.value"
+                                    class="text-muted small"
+                                >
+                                    [<field name="default_code" />]
                                 </div>
 
                                 <!-- Stock availability -->
                                 <div class="mt-2">
-                                    <span t-if="record.qty_available.raw_value > 5"
-                                          class="badge rounded-pill text-bg-success">
-                                        <i class="fa fa-check"/> <field name="qty_available"/> Available
+                                    <span
+                                        t-if="record.qty_available.raw_value > 5"
+                                        class="badge rounded-pill text-bg-success"
+                                    >
+                                        <i class="fa fa-check" /> <field
+                                            name="qty_available"
+                                        /> Available
                                     </span>
-                                    <span t-elif="record.qty_available.raw_value > 0"
-                                          class="badge rounded-pill text-bg-warning">
-                                        <i class="fa fa-exclamation"/> <field name="qty_available"/> Left
+                                    <span
+                                        t-elif="record.qty_available.raw_value > 0"
+                                        class="badge rounded-pill text-bg-warning"
+                                    >
+                                        <i class="fa fa-exclamation" /> <field
+                                            name="qty_available"
+                                        /> Left
                                     </span>
-                                    <span t-else="" class="badge rounded-pill text-bg-danger">
-                                        <i class="fa fa-times"/> Unavailable
+                                    <span
+                                        t-else=""
+                                        class="badge rounded-pill text-bg-danger"
+                                    >
+                                        <i class="fa fa-times" /> Unavailable
                                     </span>
                                 </div>
                             </div>
@@ -76,10 +98,10 @@
         <field name="model">product.product</field>
         <field name="arch" type="xml">
             <tree string="Rental Products" multi_edit="1">
-                <field name="name"/>
-                <field name="default_code" optional="show"/>
-                <field name="qty_available" string="On Hand"/>
-                <field name="rental_color" widget="color_picker" optional="hide"/>
+                <field name="name" />
+                <field name="default_code" optional="show" />
+                <field name="qty_available" string="On Hand" />
+                <field name="rental_color" widget="color_picker" optional="hide" />
             </tree>
         </field>
     </record>
@@ -90,26 +112,38 @@
         <field name="model">product.product</field>
         <field name="arch" type="xml">
             <search string="Search Rental Products">
-                <field name="name"/>
-                <field name="default_code"/>
-                <field name="categ_id"/>
+                <field name="name" />
+                <field name="default_code" />
+                <field name="categ_id" />
 
-                <separator/>
-                <filter name="filter_in_stock" string="In Stock"
-                        domain="[('qty_available', '&gt;', 0)]"/>
-                <filter name="filter_out_of_stock" string="Out of Stock"
-                        domain="[('qty_available', '&lt;=', 0)]"/>
+                <separator />
+                <filter
+                    name="filter_in_stock"
+                    string="In Stock"
+                    domain="[('qty_available', '&gt;', 0)]"
+                />
+                <filter
+                    name="filter_out_of_stock"
+                    string="Out of Stock"
+                    domain="[('qty_available', '&lt;=', 0)]"
+                />
 
-                <separator/>
+                <separator />
                 <group expand="0" string="Group By">
-                    <filter name="group_categ" string="Category"
-                            context="{'group_by': 'categ_id'}"/>
-                    <filter name="group_type" string="Product Type"
-                            context="{'group_by': 'detailed_type'}"/>
+                    <filter
+                        name="group_categ"
+                        string="Category"
+                        context="{'group_by': 'categ_id'}"
+                    />
+                    <filter
+                        name="group_type"
+                        string="Product Type"
+                        context="{'group_by': 'detailed_type'}"
+                    />
                 </group>
 
                 <searchpanel>
-                    <field name="categ_id" icon="fa-folder" enable_counters="1"/>
+                    <field name="categ_id" icon="fa-folder" enable_counters="1" />
                 </searchpanel>
             </search>
         </field>
@@ -120,7 +154,7 @@
         <field name="name">Rental Products</field>
         <field name="res_model">product.product</field>
         <field name="view_mode">kanban,tree,form</field>
-        <field name="search_view_id" ref="product_product_search_view_rental"/>
+        <field name="search_view_id" ref="product_product_search_view_rental" />
         <field name="domain">[('rental_service_ids', '!=', False)]</field>
         <field name="context">{'search_default_filter_in_stock': 1}</field>
         <field name="help" type="html">
@@ -135,18 +169,24 @@
     </record>
 
     <!-- Explicit view references for action -->
-    <record id="product_product_rental_action_view_kanban" model="ir.actions.act_window.view">
+    <record
+        id="product_product_rental_action_view_kanban"
+        model="ir.actions.act_window.view"
+    >
         <field name="sequence">1</field>
         <field name="view_mode">kanban</field>
-        <field name="view_id" ref="product_product_kanban_view_rental"/>
-        <field name="act_window_id" ref="product_product_rental_action"/>
+        <field name="view_id" ref="product_product_kanban_view_rental" />
+        <field name="act_window_id" ref="product_product_rental_action" />
     </record>
 
-    <record id="product_product_rental_action_view_tree" model="ir.actions.act_window.view">
+    <record
+        id="product_product_rental_action_view_tree"
+        model="ir.actions.act_window.view"
+    >
         <field name="sequence">2</field>
         <field name="view_mode">tree</field>
-        <field name="view_id" ref="product_product_tree_view_rental"/>
-        <field name="act_window_id" ref="product_product_rental_action"/>
+        <field name="view_id" ref="product_product_tree_view_rental" />
+        <field name="act_window_id" ref="product_product_rental_action" />
     </record>
 
 </odoo>

--- a/rental_dashboard/views/sale_order_line_views.xml
+++ b/rental_dashboard/views/sale_order_line_views.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <odoo>
 
     <!-- Calendar view for rental sale order lines -->
@@ -6,20 +6,22 @@
         <field name="name">sale.order.line.calendar.rental</field>
         <field name="model">sale.order.line</field>
         <field name="arch" type="xml">
-            <calendar string="Rental Calendar"
-                      date_start="start_datetime"
-                      date_stop="end_datetime"
-                      color="order_partner_id"
-                      mode="month"
-                      quick_add="false"
-                      event_open_popup="true"
-                      create_name_field="rental_display_name">
-                <field name="rental_display_name"/>
-                <field name="order_id"/>
-                <field name="order_partner_id"/>
-                <field name="product_id"/>
-                <field name="rental_qty"/>
-                <field name="state"/>
+            <calendar
+                string="Rental Calendar"
+                date_start="start_datetime"
+                date_stop="end_datetime"
+                color="order_partner_id"
+                mode="month"
+                quick_add="false"
+                event_open_popup="true"
+                create_name_field="rental_display_name"
+            >
+                <field name="rental_display_name" />
+                <field name="order_id" />
+                <field name="order_partner_id" />
+                <field name="product_id" />
+                <field name="rental_qty" />
+                <field name="state" />
             </calendar>
         </field>
     </record>

--- a/rental_dashboard/views/sale_order_line_views.xml
+++ b/rental_dashboard/views/sale_order_line_views.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Calendar view for rental sale order lines -->
+    <record id="sale_order_line_calendar_view_rental" model="ir.ui.view">
+        <field name="name">sale.order.line.calendar.rental</field>
+        <field name="model">sale.order.line</field>
+        <field name="arch" type="xml">
+            <calendar string="Rental Calendar"
+                      date_start="start_datetime"
+                      date_stop="end_datetime"
+                      color="order_partner_id"
+                      mode="month"
+                      quick_add="false"
+                      event_open_popup="true"
+                      create_name_field="rental_display_name">
+                <field name="rental_display_name"/>
+                <field name="order_id"/>
+                <field name="order_partner_id"/>
+                <field name="product_id"/>
+                <field name="rental_qty"/>
+                <field name="state"/>
+            </calendar>
+        </field>
+    </record>
+
+</odoo>

--- a/setup/rental_dashboard/odoo/addons/rental_dashboard
+++ b/setup/rental_dashboard/odoo/addons/rental_dashboard
@@ -1,0 +1,1 @@
+../../../../rental_dashboard

--- a/setup/rental_dashboard/setup.py
+++ b/setup/rental_dashboard/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,2 @@
+odoo-addon-sale_rental @ git+https://github.com/OCA/vertical-rental.git@refs/pull/78/head#subdirectory=setup/sale_rental
+odoo-addon-rental_base @ git+https://github.com/OCA/vertical-rental.git@refs/pull/78/head#subdirectory=setup/rental_base


### PR DESCRIPTION
**Rental Dashboard**

A unified dashboard for managing rental operations, built as an
OWL client action embedded in the Odoo backend.

**What it does**

- **Calendar view** — Displays all active rental bookings on a month calendar, color-coded by customer. Users can see at a glance when equipment is booked and by whom.

- **Product sidebar** — Lists all rental-eligible products with real-time availability (available / total fleet), calculated from warehouse stock minus committed rentals.

- **Filtering** — Filter by warehouse location, date range, and stock availability. Selecting a location scopes both the product list and calendar to that warehouse. Date range highlights the selected period on the calendar and recalculates availability for that window.

- **Quick booking** — Create rental orders directly from the dashboard: select products from the sidebar, drag a date range on the calendar, or click "Create rental". A modal lets you pick customer, warehouse, dates, equipment, rental period, and quantity — with live pricing and availability checks.

- **Edit bookings** — Click any calendar event to open the rental order in an edit modal. View order status, modify lines, confirm the order, or navigate to the full sale order form.

- **Hover tooltips** — Hovering over a calendar event shows a tooltip with product name, customer, order reference, dates, and quantity.
<img width="1902" height="949" alt="image" src="https://github.com/user-attachments/assets/126e732b-4b79-40d7-9054-44e6cd7e59c4" />
