### PR TITLE
[16.0][MIG] add missing feature from 12.0

### DIFF
--- a/rental_base/__manifest__.py
+++ b/rental_base/__manifest__.py
@@ -5,6 +5,27 @@
     "version": "16.0.1.0.0",
     "category": "Rental",
     "summary": "Manage Rental of Products",
+    "usage": """
+Create a rentable product and its rental service.
+ * Go to Rentals > Configuration > Settings.
+ * Please activate the checkbox for using 'Product Variants'.
+ * Go to Rentals > Products > Products.
+ * Create a new storable product.
+ * Activate the checkbox 'Can be Rented'.
+ * Go to page 'Sales & Purchase'.
+ * Create the rental service and configure its name and price.
+
+Create a rental order:
+ * Go to Rentals > Customer > Rental Quotations.
+ * Create a new order and choose the type 'Rental Order'.
+ * Add the rental service as an order line.
+ * Set the quantity to rent out one or several storable rentable products.
+ * Choose start and end date.
+ * Confirm the order.
+ * Check out the two deliveries, one for outgoing and one for incoming delivery.
+
+Please also see the usage section of sale_rental module.
+""",
     "author": "elego Software Solutions GmbH, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/vertical-rental",
     "depends": [
@@ -19,6 +40,7 @@
     ],
     "data": [
         "security/ir.model.access.csv",
+        "security/rental_security.xml",
         "data/ir_sequence_data.xml",
         "data/order_type_data.xml",
         "data/product_uom_data.xml",

--- a/rental_base/data/product_uom_data.xml
+++ b/rental_base/data/product_uom_data.xml
@@ -6,4 +6,10 @@
             <field ref="uom.uom_categ_wtime" name="category_id" />
             <field name="factor" eval="0.033" />
         </record>
+        <record id="product_uom_week" model="uom.uom">
+            <field name="name">Week(s)</field>
+            <field name="uom_type">bigger</field>
+            <field ref="uom.uom_categ_wtime" name="category_id" />
+            <field name="factor" eval="0.143" />
+        </record>
 </odoo>

--- a/rental_base/models/product.py
+++ b/rental_base/models/product.py
@@ -1,26 +1,9 @@
 # Part of rental-vertical See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
     rental = fields.Boolean("Can be Rent")
-
-
-class ProductProduct(models.Model):
-    _inherit = "product.product"
-
-    rental = fields.Boolean(
-        "Can be Rent", compute="_compute_rental", inverse="_inverse_rental", store=True
-    )
-
-    @api.depends("product_tmpl_id.rental")
-    def _compute_rental(self):
-        for product in self:
-            product.rental = product.product_tmpl_id.rental
-
-    def _inverse_rental(self):
-        for product in self:
-            product.product_tmpl_id.rental = product.rental

--- a/rental_base/models/sale.py
+++ b/rental_base/models/sale.py
@@ -1,5 +1,6 @@
 # Part of rental-vertical See LICENSE file for full copyright and licensing details.
 import datetime
+from math import ceil
 
 from odoo import _, api, exceptions, fields, models
 from odoo.exceptions import ValidationError
@@ -18,6 +19,11 @@ class SaleOrder(models.Model):
     default_end_date = fields.Date(
         compute="_compute_default_end_date",
         readonly=False,
+        store=True,
+    )
+
+    is_rental_order = fields.Boolean(
+        compute="_compute_is_rental_order",
         store=True,
     )
 
@@ -53,6 +59,19 @@ class SaleOrder(models.Model):
                     }
                 )
 
+    @api.depends("type_id")
+    def _compute_is_rental_order(self):
+        try:
+            rental_type = self.sudo().env.ref("rental_base.rental_sale_type")
+        except ValueError:
+            for order in self:
+                order.is_rental_order = False
+            return
+        for order in self:
+            order.is_rental_order = False
+            if order.type_id.id == rental_type.id:
+                order.is_rental_order = True
+
     def unlink(self):
         for rec in self:
             rentals = self.env["sale.rental"].search(
@@ -87,13 +106,6 @@ class SaleOrderLine(models.Model):
             "sale": [("readonly", False)],
         }
     )
-
-    rental = fields.Boolean(compute="_compute_rental", store=True)
-
-    @api.depends("product_id")
-    def _compute_rental(self):
-        for line in self:
-            line.rental = line.product_id.rental
 
     @api.constrains(
         "rental_type",
@@ -160,6 +172,26 @@ class SaleOrderLine(models.Model):
                         }
                     )
 
+    # use this field to show the widget radio for field rental
+    order_type = fields.Selection(
+        selection=[("normal", "Normal"), ("rental", "Rental")],
+        compute="_compute_order_type",
+        inverse="_inverse_order_type",
+    )
+
+    @api.depends("rental")
+    def _compute_order_type(self):
+        for rec in self:
+            rec.order_type = "rental" if rec.rental else "normal"
+
+    def _inverse_order_type(self):
+        for rec in self:
+            rec.rental = rec.order_type == "rental"
+
+    @api.onchange("order_type")
+    def _onchange_order_type(self):
+        self.rental = self.order_type == "rental"
+
     def _prepare_invoice_line(self, **optional_values):
         self.ensure_one()
         res = super()._prepare_invoice_line(**optional_values)
@@ -170,10 +202,12 @@ class SaleOrderLine(models.Model):
     @api.model
     def _get_time_uom(self):
         uom_month = self.env.ref("rental_base.product_uom_month")
+        uom_week = self.env.ref("rental_base.product_uom_week")
         uom_day = self.env.ref("uom.product_uom_day")
         uom_hour = self.env.ref("uom.product_uom_hour")
         return {
             "month": uom_month,
+            "week": uom_week,
             "day": uom_day,
             "hour": uom_hour,
         }
@@ -191,6 +225,8 @@ class SaleOrderLine(models.Model):
             # https://www.checkyourmath.com/convert/time/days_months.php
             number = ((self.end_date - self.start_date).days + 1) / 30.4167
             number = float_round(number, precision_rounding=1)
+        elif self.product_uom.id == time_uoms["week"].id:
+            number = ceil(((self.end_date - self.start_date).days + 1) / 7)
         return number
 
     def update_start_end_date(self, date_start, date_end):

--- a/rental_base/security/rental_security.xml
+++ b/rental_base/security/rental_security.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<odoo>
+    <record id="group_rental_menu" model="res.groups">
+        <field name="name">See Rental Menu</field>
+        <field
+            name="users"
+            eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
+        />
+    </record>
+</odoo>

--- a/rental_base/tests/__init__.py
+++ b/rental_base/tests/__init__.py
@@ -1,3 +1,4 @@
 # Part of rental-vertical See LICENSE file for full copyright and licensing details.
 from . import stock_common
 from . import test_update_time_rental_order
+from . import test_create_unlink_rental_order

--- a/rental_base/tests/test_create_unlink_rental_order.py
+++ b/rental_base/tests/test_create_unlink_rental_order.py
@@ -1,0 +1,55 @@
+# Part of rental-vertical See LICENSE file for full copyright and licensing details.
+
+from odoo import fields
+
+from odoo.addons.rental_base.tests.stock_common import RentalStockCommon
+
+
+class TestCreateUnlinkRentalOrder(RentalStockCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        ProductObj = cls.env["product.product"]
+        cls.SaleOrderObj = cls.env["sale.order"]
+        cls.product_rental = ProductObj.create(
+            {
+                "name": "Rental Product",
+                "type": "product",
+                "categ_id": cls.category_all.id,
+            }
+        )
+        # rental service product
+        cls.service_rental = cls._create_rental_service_day(product=cls.product_rental)
+        # dates
+        cls.date_0101 = fields.Date.from_string("2021-01-01")
+        cls.date_0110 = fields.Date.from_string("2021-01-10")
+
+    def test_01_unlink_rental_order(self):
+        rental_order_1 = self._create_rental_order(
+            self.partnerA.id, self.date_0101, self.date_0110
+        )
+        self.assertEqual(rental_order_1.is_rental_order, True)
+        rental_order_1.action_confirm()
+        self.assertEqual(rental_order_1.delivery_count, 2)
+        self.assertEqual(len(rental_order_1.order_line), 1)
+        line = rental_order_1.order_line[0]
+        rental_1 = self.env["sale.rental"].search(
+            [
+                ("start_order_line_id", "=", line.id),
+                ("state", "!=", "cancel"),
+                ("out_move_id.state", "!=", "cancel"),
+                ("in_move_id.state", "!=", "cancel"),
+            ]
+        )
+        self.assertEqual(len(rental_1), 1)
+        rental_order_1.with_context(disable_cancel_warning=True).action_cancel()
+        rental_order_1.unlink()
+        rental_1_after = self.env["sale.rental"].search(
+            [
+                ("start_order_line_id", "=", line.id),
+                ("state", "!=", "cancel"),
+                ("out_move_id.state", "!=", "cancel"),
+                ("in_move_id.state", "!=", "cancel"),
+            ]
+        )
+        self.assertEqual(len(rental_1_after), 0)

--- a/rental_base/tests/test_update_time_rental_order.py
+++ b/rental_base/tests/test_update_time_rental_order.py
@@ -86,14 +86,14 @@ class TestUpdateTimeRentalOrder(RentalStockCommon):
         self.assertEqual(len(rental_1), 1)
         self.assertEqual(
             rental_1.out_picking_id.scheduled_date.date(),
-            self.date_0101,
+            self.date_0102,
         )
         self.assertEqual(
             rental_1.in_picking_id.scheduled_date.date(),
-            self.date_0110,
+            self.date_0111,
         )
-        self.assertEqual(rental_1.out_move_id.date.date(), self.date_0101)
-        self.assertEqual(rental_1.in_move_id.date.date(), self.date_0110)
+        self.assertEqual(rental_1.out_move_id.date.date(), self.date_0102)
+        self.assertEqual(rental_1.in_move_id.date.date(), self.date_0111)
         # 2. change date, date_in_lines = True
         line_ids_value_2 = []
         line_ids_value_2.append(
@@ -144,18 +144,14 @@ class TestUpdateTimeRentalOrder(RentalStockCommon):
         self.assertEqual(len(rental_2), 1)
         self.assertEqual(
             rental_2.out_picking_id.scheduled_date.date(),
-            self.date_0101,
+            self.date_0103,
         )
         self.assertEqual(
             rental_2.in_picking_id.scheduled_date.date(),
-            self.date_0110,
+            self.date_0112,
         )
-        self.assertEqual(rental_2.out_move_id.date.date(), self.date_0101)
-        self.assertEqual(rental_2.in_move_id.date.date(), self.date_0110)
-
-    def test_inverse_rental(self):
-        self.product_rental.rental = True
-        self.assertTrue(self.product_rental.product_tmpl_id.rental)
+        self.assertEqual(rental_2.out_move_id.date.date(), self.date_0103)
+        self.assertEqual(rental_2.in_move_id.date.date(), self.date_0112)
 
     def test_create_sale_order_order_type_rental(self):
         number_next_actual = self.env.ref(

--- a/rental_base/views/menu_view.xml
+++ b/rental_base/views/menu_view.xml
@@ -4,24 +4,18 @@
         <field name="name">Sales Orders</field>
         <field
             name="context"
-            eval="{'default_type_id': ref('sale_order_type.normal_sale_type')}"
+            eval="{'default_type_id': ref('sale_order_type.normal_sale_type'), 'search_default_is_normal_order': 1}"
         />
-        <field
-            name="domain"
-            eval="[('type_id','!=', ref('rental_sale_type')), ('state', 'not in', ('draft', 'sent'))]"
-        />
+        <field name="domain" eval="[('state', 'not in', ('draft', 'sent'))]" />
     </record>
 
     <record id="sale.action_quotations" model="ir.actions.act_window">
         <field name="name">Sales Quotations</field>
         <field
             name="context"
-            eval="{'search_default_my_quotation': 1, 'default_type_id': ref('sale_order_type.normal_sale_type')}"
+            eval="{'search_default_my_quotation': 1, 'default_type_id': ref('sale_order_type.normal_sale_type'), 'search_default_is_normal_order': 1}"
         />
-        <field
-            name="domain"
-            eval="[('type_id','!=', ref('rental_sale_type')), ('state', 'in', ('draft', 'sent', 'cancel'))]"
-        />
+        <field name="domain" eval="[('state', 'in', ('draft', 'sent', 'cancel'))]" />
     </record>
 
     <record id="action_rental_orders" model="ir.actions.act_window">
@@ -30,11 +24,11 @@
         <field name="res_model">sale.order</field>
         <field name="view_mode">tree,kanban,form,calendar,pivot,graph,activity</field>
         <field name="search_view_id" ref="sale.sale_order_view_search_inherit_sale" />
-        <field name="context" eval="{'default_type_id': ref('rental_sale_type')}" />
         <field
-            name="domain"
-            eval="[('type_id','=', ref('rental_sale_type')), ('state', 'not in', ('draft', 'sent'))]"
+            name="context"
+            eval="{'default_type_id': ref('rental_sale_type'), 'search_default_is_rental_order': 1}"
         />
+        <field name="domain" eval="[('state', 'not in', ('draft', 'sent'))]" />
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Create a new quotation, the first step of a new sale!
@@ -51,11 +45,11 @@
         <field name="res_model">sale.order</field>
         <field name="view_mode">tree,kanban,form,calendar,pivot,graph,activity</field>
         <field name="search_view_id" ref="sale.sale_order_view_search_inherit_sale" />
-        <field name="context" eval="{'default_type_id': ref('rental_sale_type')}" />
         <field
-            name="domain"
-            eval="[('type_id','=', ref('rental_sale_type')), ('state', 'in', ['draft', 'sent', 'cancel'])]"
+            name="context"
+            eval="{'default_type_id': ref('rental_sale_type'), 'search_default_is_rental_order': 1}"
         />
+        <field name="domain" eval="[('state', 'in', ['draft', 'sent', 'cancel'])]" />
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Create a new quotation, the first step of a new sale!
@@ -80,6 +74,7 @@
         name="Rentals"
         id="menu_rental_root"
         sequence="5"
+        groups="group_rental_menu"
         web_icon="rental_base,static/description/icon.png"
     />
 

--- a/rental_base/views/product_views.xml
+++ b/rental_base/views/product_views.xml
@@ -6,9 +6,14 @@
         <field name="arch" type="xml">
             <xpath expr="//div[@name='options']" position="inside">
                 <div>
-                    <field name="rental" readonly="0" />
+                    <field name="rental" />
                     <label for="rental" />
                 </div>
+            </xpath>
+            <xpath expr="//page[@name='sales']" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'invisible': [('sale_ok','=',False), ('rental','=',False)]}</attribute>
             </xpath>
         </field>
     </record>

--- a/rental_base/views/sale_view.xml
+++ b/rental_base/views/sale_view.xml
@@ -238,13 +238,19 @@
                 />
                 <field name="name" nolabel="1" colspan="2" />
             </xpath>
+
             <xpath
                 expr="//group//field[@name='analytic_distribution']/.."
                 position="inside"
             >
                 <!-- Group: Rental Settings -->
                 <group id="rental_settings" string="Rental Settings" colspan="4">
-                    <field name="rental" />
+                    <field name="rental" invisible="1" />
+                    <field
+                        name="order_type"
+                        widget="radio"
+                        options="{'horizontal': True}"
+                    />
                     <field
                         name="rental_type"
                         attrs="{'invisible': [('rental', '=', False)],
@@ -380,4 +386,26 @@
             </xpath>
         </field>
     </record>
+
+    <record id="view_sales_order_filter" model="ir.ui.view">
+        <field name="name">rental_base.sales_order_filter</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_sales_order_filter" />
+        <field name="arch" type="xml">
+            <xpath expr="//filter[@name='my_sale_orders_filter']" position="after">
+                <separator />
+                <filter
+                    string="Normal Order"
+                    domain="[('is_rental_order','=',False)]"
+                    name="is_normal_order"
+                />
+                <filter
+                    string="Rental Order"
+                    domain="[('is_rental_order','=',True)]"
+                    name="is_rental_order"
+                />
+            </xpath>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
I've added some missing features that we had implemented for 12.0.
I have also done the following refactoring of the existing code:

1) I deleted the computed field rental on product.product, because we can use the field from product.template.
```
class ProductProduct(models.Model):
    _inherit = "product.product"

    rental = fields.Boolean(
        "Can be Rent", compute="_compute_rental", inverse="_inverse_rental", store=True
    )

    @api.depends("product_tmpl_id.rental")
    def _compute_rental(self):
        for product in self:
            product.rental = product.product_tmpl_id.rental

    def _inverse_rental(self):
        for product in self:
            product.product_tmpl_id.rental = product.rental
``` 
2) I have deleted the override of the field rental on sale.order.line. Due to the feature in rental_pricelist, we should also be able to sell the rentable product.

```
    rental = fields.Boolean(compute="_compute_rental", store=True)

    @api.depends("product_id")
    def _compute_rental(self):
        for line in self:
            line.rental = line.product_id.rental
```