### PR TITLE
[16.0][FIX] rental_base: removed incorrect label

### DIFF
--- a/rental_base/views/sale_view.xml
+++ b/rental_base/views/sale_view.xml
@@ -279,7 +279,7 @@
                     attrs="{'invisible': [('rental', '=', False)]}"
                 >
                     <field name="number_of_days" />
-                    <label for="product_uom_qty" string="Ordered Rental Time" />
+                    <label for="product_uom_qty" />
                     <div>
                         <field
                             name="product_uom_qty"


### PR DESCRIPTION
The label in the sale order lines is referencing another field, making it confusing for users

_before_:
<img width="436" height="182" alt="Screenshot from 2026-08-15 10-52-40" src="https://github.com/user-attachments/assets/2d9e361f-fcad-4f3a-b36f-e237908b4d68" />

_after_:
<img width="436" height="182" alt="image" src="https://github.com/user-attachments/assets/be93d50c-99b2-4091-b742-6b358f28c878" />
